### PR TITLE
[Feat]: 회원가입 페이지 구현

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -4,6 +4,8 @@ import type {
   LoginRequest,
   LoginResult,
   RefreshTokenResult,
+  SignupRequest,
+  SignupResult,
 } from "@/types/auth";
 import { http } from "@/utils/http";
 
@@ -12,6 +14,17 @@ export const login = async (payload: LoginRequest): Promise<LoginResult> => {
     LoginRequest,
     { data: ApiResponse<LoginResult> }
   >(ENDPOINT.AUTH.LOGIN, payload);
+  return data.result;
+};
+
+export const signup = async (payload: SignupRequest): Promise<SignupResult> => {
+  const { data } = await http.post<
+    SignupRequest,
+    { data: ApiResponse<SignupResult> }
+  >(ENDPOINT.AUTH.SIGNUP, payload);
+  if (!data.isSuccess) {
+    throw new Error(data.message);
+  }
   return data.result;
 };
 

--- a/src/constants/endpoint.ts
+++ b/src/constants/endpoint.ts
@@ -7,6 +7,7 @@ const ENDPOINT = {
   TEST: `${API_BASE_URL}/test`,
   AUTH: {
     LOGIN: `${API_BASE_URL}/api/auth/login`,
+    SIGNUP: `${API_BASE_URL}/api/auth/signup`,
     REFRESH_TOKEN: `${API_BASE_URL}/api/auth/refresh-token`,
     LOGOUT: `${API_BASE_URL}/api/auth/logout`,
   },

--- a/src/pages/signup/components/SignupForm.tsx
+++ b/src/pages/signup/components/SignupForm.tsx
@@ -10,6 +10,8 @@ interface SignupFormProps {
   email: string;
   password: string;
   confirmPassword: string;
+  errorMessage: string | null;
+  isPending: boolean;
   onNameChange: (value: string) => void;
   onEmailChange: (value: string) => void;
   onPasswordChange: (value: string) => void;
@@ -22,6 +24,8 @@ export const SignupForm = ({
   email,
   password,
   confirmPassword,
+  errorMessage,
+  isPending,
   onNameChange,
   onEmailChange,
   onPasswordChange,
@@ -121,15 +125,21 @@ export const SignupForm = ({
       </div>
 
       <div className="flex w-full flex-col items-center gap-3">
+        {errorMessage && (
+          <p className="typo-body6 text-red-500" role="alert">
+            {errorMessage}
+          </p>
+        )}
         <button
           type="submit"
+          disabled={isPending}
           className="typo-button-md flex w-full cursor-pointer items-center justify-center rounded-full py-3 text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
           style={{
             background:
               "linear-gradient(164.49deg, rgb(91, 141, 239) 15.47%, rgb(0, 99, 247) 84.42%)",
           }}
         >
-          가입하기
+          {isPending ? "가입 중..." : "가입하기"}
         </button>
 
         <div className="flex items-center justify-center gap-2 whitespace-nowrap">

--- a/src/pages/signup/components/SignupForm.tsx
+++ b/src/pages/signup/components/SignupForm.tsx
@@ -1,0 +1,149 @@
+import { Link } from "react-router-dom";
+import iconCamera from "@/assets/icons/media/ic_camera.svg";
+import { Icon } from "@/components/common/Icon";
+import LogoSymbol from "@/components/logo/LogoSymbol";
+import LogoText from "@/components/logo/LogoText";
+import { ROUTES } from "@/constants/routes";
+
+interface SignupFormProps {
+  name: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  onNameChange: (value: string) => void;
+  onEmailChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onConfirmPasswordChange: (value: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+}
+
+export const SignupForm = ({
+  name,
+  email,
+  password,
+  confirmPassword,
+  onNameChange,
+  onEmailChange,
+  onPasswordChange,
+  onConfirmPasswordChange,
+  onSubmit,
+}: SignupFormProps) => {
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="relative flex w-full max-w-110 flex-col items-center gap-10 overflow-hidden rounded-[30px] border border-white px-7 pb-10 pt-20"
+      style={{ background: "rgba(255, 255, 255, 0.3)" }}
+    >
+      {/* Logo */}
+      <section className="flex flex-col items-center gap-3" aria-label="WhyLog">
+        <LogoSymbol className="h-15 w-17.5" aria-hidden="true" />
+        <LogoText className="h-13 w-38" aria-hidden="true" />
+        <p className="typo-body5 text-text-secondary">
+          회의 기반 의사결정 관리 플랫폼
+        </p>
+      </section>
+
+      <div className="flex w-full flex-col gap-3">
+        <div className="flex w-full flex-col gap-1">
+          <p className="typo-label text-text-secondary">프로필 이미지</p>
+          <div className="flex w-full items-center gap-3">
+            <button
+              type="button"
+              className="flex size-12 shrink-0 items-center justify-center rounded-full border border-white bg-white/10"
+              aria-label="프로필 이미지 업로드"
+            >
+              <Icon icon={iconCamera} size={16} className="text-text-inverse" />
+            </button>
+            <p className="typo-caption1 whitespace-nowrap text-text-tertiary">
+              클릭하여 프로필 사진을 업로드하세요
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="name" className="typo-label text-text-secondary">
+            이름
+          </label>
+          <input
+            id="name"
+            type="text"
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            placeholder="Name"
+            className="typo-body6 h-11 w-full rounded-full border border-white bg-transparent px-4 py-3 text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-white"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="email" className="typo-label text-text-secondary">
+            이메일
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => onEmailChange(e.target.value)}
+            placeholder="E-mail"
+            className="typo-body6 h-11 w-full rounded-full border border-white bg-transparent px-4 py-3 text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-white"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="password" className="typo-label text-text-secondary">
+            비밀번호
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => onPasswordChange(e.target.value)}
+            placeholder="Password"
+            className="typo-body6 h-11 w-full rounded-full border border-white bg-transparent px-4 py-3 text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-white"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="confirm-password"
+            className="typo-label text-text-secondary"
+          >
+            비밀번호 확인
+          </label>
+          <input
+            id="confirm-password"
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => onConfirmPasswordChange(e.target.value)}
+            placeholder="Confirm Password"
+            className="typo-body6 h-11 w-full rounded-full border border-white bg-transparent px-4 py-3 text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-white"
+          />
+        </div>
+      </div>
+
+      <div className="flex w-full flex-col items-center gap-3">
+        <button
+          type="submit"
+          className="typo-button-md flex w-full cursor-pointer items-center justify-center rounded-full py-3 text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          style={{
+            background:
+              "linear-gradient(164.49deg, rgb(91, 141, 239) 15.47%, rgb(0, 99, 247) 84.42%)",
+          }}
+        >
+          가입하기
+        </button>
+
+        <div className="flex items-center justify-center gap-2 whitespace-nowrap">
+          <span className="typo-body6 text-text-secondary">
+            이미 계정이 있으신가요?
+          </span>
+          <Link
+            to={ROUTES.LOGIN}
+            className="typo-button-sm text-text-brand hover:underline"
+          >
+            로그인
+          </Link>
+        </div>
+      </div>
+    </form>
+  );
+};

--- a/src/pages/signup/hooks/useSignup.ts
+++ b/src/pages/signup/hooks/useSignup.ts
@@ -1,0 +1,24 @@
+import { useState } from "react";
+
+export const useSignup = () => {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+  };
+
+  return {
+    name,
+    email,
+    password,
+    confirmPassword,
+    setName,
+    setEmail,
+    setPassword,
+    setConfirmPassword,
+    handleSubmit,
+  };
+};

--- a/src/pages/signup/hooks/useSignup.ts
+++ b/src/pages/signup/hooks/useSignup.ts
@@ -44,6 +44,7 @@ export const useSignup = () => {
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
+    if (signupMutation.isPending) return;
     setErrorMessage(null);
 
     const validationError = validate();

--- a/src/pages/signup/hooks/useSignup.ts
+++ b/src/pages/signup/hooks/useSignup.ts
@@ -53,6 +53,7 @@ export const useSignup = () => {
       return;
     }
 
+    // TODO: 프로필 이미지 업로드 API 연동
     signupMutation.mutate({
       name: name.trim(),
       email: email.trim(),

--- a/src/pages/signup/hooks/useSignup.ts
+++ b/src/pages/signup/hooks/useSignup.ts
@@ -1,13 +1,62 @@
+import { useMutation } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { signup } from "@/apis/auth";
+import { ROUTES } from "@/constants/routes";
+import type { ApiResponse, SignupResult } from "@/types/auth";
+import { tokenStore } from "@/utils/tokenStore";
 
 export const useSignup = () => {
+  const navigate = useNavigate();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const signupMutation = useMutation({
+    mutationFn: signup,
+    onSuccess: (result: SignupResult) => {
+      tokenStore.setToken(result.access_token);
+      navigate(ROUTES.APP_ROOT, { replace: true });
+    },
+    onError: (error: unknown) => {
+      if (isAxiosError<ApiResponse<unknown>>(error)) {
+        setErrorMessage(
+          error.response?.data?.message ??
+            "회원가입에 실패했습니다. 다시 시도해주세요.",
+        );
+        return;
+      }
+      setErrorMessage("회원가입에 실패했습니다. 다시 시도해주세요.");
+    },
+  });
+
+  const validate = () => {
+    if (!name.trim()) return "이름을 입력해 주세요.";
+    if (!email.trim()) return "이메일을 입력해 주세요.";
+    if (!password.trim()) return "비밀번호를 입력해 주세요.";
+    if (password.length < 8) return "비밀번호는 8자 이상이어야 합니다.";
+    if (password !== confirmPassword) return "비밀번호가 일치하지 않습니다.";
+    return null;
+  };
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
+    setErrorMessage(null);
+
+    const validationError = validate();
+    if (validationError) {
+      setErrorMessage(validationError);
+      return;
+    }
+
+    signupMutation.mutate({
+      name: name.trim(),
+      email: email.trim(),
+      password,
+    });
   };
 
   return {
@@ -15,10 +64,12 @@ export const useSignup = () => {
     email,
     password,
     confirmPassword,
+    errorMessage,
     setName,
     setEmail,
     setPassword,
     setConfirmPassword,
     handleSubmit,
+    isPending: signupMutation.isPending,
   };
 };

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,9 +1,34 @@
 import { AuthBackground } from "@/components/common/AuthBackground";
+import { SignupForm } from "./components/SignupForm";
+import { useSignup } from "./hooks/useSignup";
 
 function SignupPage() {
+  const {
+    name,
+    email,
+    password,
+    confirmPassword,
+    setName,
+    setEmail,
+    setPassword,
+    setConfirmPassword,
+    handleSubmit,
+  } = useSignup();
+
   return (
     <div className="relative flex h-screen w-screen items-center justify-center overflow-hidden">
       <AuthBackground />
+      <SignupForm
+        name={name}
+        email={email}
+        password={password}
+        confirmPassword={confirmPassword}
+        onNameChange={setName}
+        onEmailChange={setEmail}
+        onPasswordChange={setPassword}
+        onConfirmPasswordChange={setConfirmPassword}
+        onSubmit={handleSubmit}
+      />
     </div>
   );
 }

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -8,6 +8,8 @@ function SignupPage() {
     email,
     password,
     confirmPassword,
+    errorMessage,
+    isPending,
     setName,
     setEmail,
     setPassword,
@@ -23,6 +25,8 @@ function SignupPage() {
         email={email}
         password={password}
         confirmPassword={confirmPassword}
+        errorMessage={errorMessage}
+        isPending={isPending}
         onNameChange={setName}
         onEmailChange={setEmail}
         onPasswordChange={setPassword}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -10,9 +10,23 @@ export interface LoginRequest {
   password: string;
 }
 
+export interface SignupRequest {
+  name: string;
+  email: string;
+  password: string;
+}
+
 export type UserRole = "ROLE_USER" | "ROLE_ADMIN" | string;
 
 export interface LoginResult {
+  access_token: string;
+  refresh_token: string;
+  member_id: number;
+  email: string;
+  role: UserRole;
+}
+
+export interface SignupResult {
   access_token: string;
   refresh_token: string;
   member_id: number;


### PR DESCRIPTION
<!-- PR 제목 예시-> [Feat]: 소셜 로그인 기능 구현 -->

## ✨ 작업 개요
회원가입 UI 및 API 연동

## 📄 작업 내용
- 회원가입 UI 구현
- 회원가입 API 연동

## 📌 관련 이슈
- close #11 

## 📷 UI 스크린샷 (해당 시)
<img width="1470" height="837" alt="image" src="https://github.com/user-attachments/assets/6baf3ae1-e71f-4742-b76a-94f0362361a5" />

## 💬 기타 사항
<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->
- 프로필 이미지 업로드는 아직 API가 구현되지 않아, 추후 연동 예정입니다!
- 인증 및 팀 관련 API(`refresh-token`, `teams`)에서 콘솔 에러가 발생하고 있어 확인 부탁드립니다.