### PR TITLE
[Feat]: 팀 조회 API 연동 및 생성/라우팅 구조 개선

### DIFF
--- a/src/apis/teams.ts
+++ b/src/apis/teams.ts
@@ -1,7 +1,7 @@
 import type { AxiosResponse } from "axios";
 import ENDPOINT from "@/constants/endpoint";
 import type { ApiResponse } from "@/types/auth";
-import type { CreateTeamResult, Team } from "@/types/team";
+import type { CreateTeamRequest, CreateTeamResult, Team } from "@/types/team";
 import { http } from "@/utils/http";
 
 export const fetchTeams = async (): Promise<Team[]> => {
@@ -13,19 +13,17 @@ export const fetchTeams = async (): Promise<Team[]> => {
 };
 
 export const createTeam = async (
-  name: string,
-  image?: File,
+  payload: CreateTeamRequest,
 ): Promise<CreateTeamResult> => {
   const formData = new FormData();
 
-  const requestBlob = new Blob([JSON.stringify({ name })], {
+  const requestBlob = new Blob([JSON.stringify({ name: payload.name })], {
     type: "application/json",
   });
   formData.append("request", requestBlob);
 
-  // image part: 이미지가 있을 때만 추가
-  if (image) {
-    formData.append("image", image);
+  if (payload.image) {
+    formData.append("image", payload.image);
   }
 
   const { data } = await http.post<

--- a/src/apis/teams.ts
+++ b/src/apis/teams.ts
@@ -1,7 +1,7 @@
 import type { AxiosResponse } from "axios";
 import ENDPOINT from "@/constants/endpoint";
 import type { ApiResponse } from "@/types/auth";
-import type { CreateTeamRequest, CreateTeamResult, Team } from "@/types/team";
+import type { CreateTeamResult, Team } from "@/types/team";
 import { http } from "@/utils/http";
 
 export const fetchTeams = async (): Promise<Team[]> => {
@@ -13,14 +13,33 @@ export const fetchTeams = async (): Promise<Team[]> => {
 };
 
 export const createTeam = async (
-  payload: CreateTeamRequest,
+  name: string,
+  image?: File,
 ): Promise<CreateTeamResult> => {
+  const formData = new FormData();
+
+  const requestBlob = new Blob([JSON.stringify({ name })], {
+    type: "application/json",
+  });
+  formData.append("request", requestBlob);
+
+  // image part: 이미지가 있을 때만 추가
+  if (image) {
+    formData.append("image", image);
+  }
+
   const { data } = await http.post<
-    CreateTeamRequest,
+    FormData,
     AxiosResponse<ApiResponse<CreateTeamResult>>
-  >(ENDPOINT.TEAMS.CREATE, payload);
+  >(ENDPOINT.TEAMS.CREATE, formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
   if (!data.isSuccess) {
     throw new Error(data.message);
   }
+
   return data.result;
 };

--- a/src/components/common/EmptyStateCard/index.tsx
+++ b/src/components/common/EmptyStateCard/index.tsx
@@ -35,7 +35,7 @@ const EmptyStateCard = ({ page, onAction }: EmptyStateCardProps) => {
       <button
         type="button"
         onClick={onAction}
-        className="flex cursor-pointer items-center gap-2 rounded-xl bg-gradient-to-br from-[#5B8DEF] to-[#0063F7] px-7 py-3.5 shadow-[0px_4px_12px_0px_rgba(30,91,232,0.2)]"
+        className="flex cursor-pointer items-center gap-2 rounded-xl bg-linear-to-br from-[#5B8DEF] to-[#0063F7] px-7 py-3.5 shadow-[0px_4px_12px_0px_rgba(30,91,232,0.2)]"
       >
         <Icon icon={IconAddPlus} size={16} className="text-white" />
         <span className="typo-button-md text-(--color-text-inverse)">

--- a/src/components/common/TeamImage.tsx
+++ b/src/components/common/TeamImage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface TeamImageProps {
   src: string | null | undefined;
@@ -14,6 +14,10 @@ export const TeamImage = ({
   className = "",
 }: TeamImageProps) => {
   const [imageError, setImageError] = useState(false);
+
+  useEffect(() => {
+    setImageError(false);
+  }, []);
 
   const showFallback = !src || imageError;
 

--- a/src/components/common/TeamImage.tsx
+++ b/src/components/common/TeamImage.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+interface TeamImageProps {
+  src: string | null | undefined;
+  alt: string;
+  size: number;
+  className?: string;
+}
+
+export const TeamImage = ({
+  src,
+  alt,
+  size,
+  className = "",
+}: TeamImageProps) => {
+  const [imageError, setImageError] = useState(false);
+
+  const showFallback = !src || imageError;
+
+  if (showFallback) {
+    return (
+      <div
+        className={`shrink-0 rounded-sm bg-gray-400 ${className}`}
+        style={{ width: `${size}px`, height: `${size}px` }}
+        role="img"
+        aria-label={alt}
+      />
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={`shrink-0 rounded-sm object-cover ${className}`}
+      style={{ width: `${size}px`, height: `${size}px` }}
+      onError={() => setImageError(true)}
+      loading="lazy"
+    />
+  );
+};

--- a/src/components/panel/MeetingPanel.tsx
+++ b/src/components/panel/MeetingPanel.tsx
@@ -4,6 +4,7 @@ import IconAddPlusSquare from "@/assets/icons/edit/ic_add_plus_square.svg?react"
 import IconSearch from "@/assets/icons/interface/ic_search.svg?react";
 import { Icon } from "@/components/common/Icon";
 import { useMeetings } from "@/contexts/MeetingsContext";
+import { useCurrentTeam } from "@/hooks/useCurrentTeam";
 import { useCreateMeeting } from "@/pages/meeting/hooks/useCreateMeeting";
 import { useElapsedTime } from "@/pages/meeting/hooks/useElapsedTime";
 import { useMeetingList } from "@/pages/meeting/hooks/useMeetingList";
@@ -13,14 +14,15 @@ import StartMeetingModal from "./StartMeetingModal";
 const MeetingPanel = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const navigate = useNavigate();
+  const { teamId } = useCurrentTeam();
   const { meetings } = useMeetings();
-  const { createMeeting, isPending } = useCreateMeeting();
+  const { createMeeting, isPending } = useCreateMeeting(teamId);
   const {
     ongoing: ongoingMeetings,
     completed: completedMeetings,
     isLoading,
     isError,
-  } = useMeetingList();
+  } = useMeetingList(teamId);
 
   const liveMeeting = meetings.find((m) => m.status === "in-progress");
   const elapsed = useElapsedTime(liveMeeting?.startedAt);
@@ -48,23 +50,27 @@ const MeetingPanel = () => {
       <div className="h-px w-full bg-(--color-border-divider)" />
 
       {/* Live meeting section */}
-      {liveMeeting && (
+      {liveMeeting && teamId && (
         <div className="flex w-full shrink-0 flex-col items-center px-4">
           <MeetingPanelItem
             title={liveMeeting.name || "진행 중인 회의"}
             isLive
             elapsedTime={elapsed}
-            onClick={() => navigate(`/meeting/${liveMeeting.id}`)}
+            onClick={() =>
+              navigate(`/team/${teamId}/meeting/${liveMeeting.id}`)
+            }
           />
         </div>
       )}
-      {!liveMeeting && apiOngoing && (
+      {!liveMeeting && apiOngoing && teamId && (
         <div className="flex w-full shrink-0 flex-col items-center px-4">
           <MeetingPanelItem
             title={apiOngoing.name}
             isLive
             elapsedTime={apiOngoing.elapse ?? "00:00:00"}
-            onClick={() => navigate(`/meeting/${apiOngoing.meetingId}`)}
+            onClick={() =>
+              navigate(`/team/${teamId}/meeting/${apiOngoing.meetingId}`)
+            }
           />
         </div>
       )}
@@ -103,7 +109,9 @@ const MeetingPanel = () => {
           <MeetingPanelItem
             key={meeting.meetingId}
             title={meeting.name}
-            onClick={() => navigate(`/meeting/${meeting.meetingId}`)}
+            onClick={() =>
+              teamId && navigate(`/team/${teamId}/meeting/${meeting.meetingId}`)
+            }
           />
         ))}
       </div>

--- a/src/components/routing/RootRedirect.tsx
+++ b/src/components/routing/RootRedirect.tsx
@@ -1,0 +1,22 @@
+import { Navigate } from "react-router-dom";
+import { useTeams } from "@/components/sidebar/hooks/useTeams";
+
+const RootRedirect = () => {
+  const { data: teams, isLoading } = useTeams();
+
+  if (isLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-lg">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (!teams || teams.length === 0) {
+    return <Navigate to="/onboarding/create-team" replace />;
+  }
+
+  return <Navigate to={`/team/${teams[0].team_id}`} replace />;
+};
+
+export default RootRedirect;

--- a/src/components/routing/RootRedirect.tsx
+++ b/src/components/routing/RootRedirect.tsx
@@ -2,12 +2,22 @@ import { Navigate } from "react-router-dom";
 import { useTeams } from "@/components/sidebar/hooks/useTeams";
 
 const RootRedirect = () => {
-  const { data: teams, isLoading } = useTeams();
+  const { data: teams, isLoading, isError } = useTeams();
 
   if (isLoading) {
     return (
       <div className="flex h-screen items-center justify-center">
         <div className="text-lg">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-lg text-red-500">
+          팀 목록을 불러오지 못했습니다.
+        </div>
       </div>
     );
   }

--- a/src/components/sidebar/components/SidebarHeader.tsx
+++ b/src/components/sidebar/components/SidebarHeader.tsx
@@ -26,7 +26,7 @@ export const SidebarHeader = ({ isOpen }: SidebarHeaderProps) => {
       setCurrentTeam({
         team_id: result.team_id,
         name: result.name,
-        team_image: result.team_image ?? null,
+        team_image: result.image_url ?? null,
       });
       setIsModalOpen(false);
     },
@@ -67,8 +67,8 @@ export const SidebarHeader = ({ isOpen }: SidebarHeaderProps) => {
     setIsModalOpen(true);
   };
 
-  const handleModalCreate = (teamName: string, _photo: File | null) => {
-    createTeam(teamName);
+  const handleModalCreate = (teamName: string, photo: File | null) => {
+    createTeam(teamName, photo ?? undefined);
   };
 
   const hasTeams = teams.length > 0;
@@ -77,7 +77,7 @@ export const SidebarHeader = ({ isOpen }: SidebarHeaderProps) => {
     <>
       <div className="relative flex items-center gap-2" ref={dropdownRef}>
         <div className="flex size-12 shrink-0 items-center justify-center">
-          <Icon icon={IconMenuBurger} size={20} className="h-[14px]" />
+          <Icon icon={IconMenuBurger} size={20} className="h-3.5" />
         </div>
         {isOpen && (
           <>

--- a/src/components/sidebar/components/SidebarHeader.tsx
+++ b/src/components/sidebar/components/SidebarHeader.tsx
@@ -75,7 +75,7 @@ export const SidebarHeader = ({ isOpen }: SidebarHeaderProps) => {
 
   return (
     <>
-      <div className="relative flex items-center gap-2" ref={dropdownRef}>
+      <div className="relative flex items-center gap-1" ref={dropdownRef}>
         <div className="flex size-12 shrink-0 items-center justify-center">
           <Icon icon={IconMenuBurger} size={20} className="h-3.5" />
         </div>
@@ -85,20 +85,24 @@ export const SidebarHeader = ({ isOpen }: SidebarHeaderProps) => {
               <button
                 type="button"
                 onClick={() => setIsDropdownOpen((prev) => !prev)}
-                className="flex cursor-pointer items-center gap-1"
+                className={`group flex cursor-pointer items-center gap-1 rounded-lg px-2 py-1 transition-colors ${
+                  isDropdownOpen ? "bg-action-active" : "hover:bg-action-hover"
+                }`}
               >
                 <TeamImage
                   src={currentTeam?.team_image}
                   alt={`${currentTeam?.name ?? "팀"} 이미지`}
                   size={18}
                 />
-                <span className="typo-subtitle3 whitespace-nowrap text-black">
+                <span className="typo-subtitle5 max-w-24 truncate text-black">
                   {currentTeam?.name ?? "팀 명"}
                 </span>
                 <Icon
                   icon={IconChevronDown}
-                  size={18}
-                  className={`transition-transform duration-200 ${isDropdownOpen ? "rotate-180" : ""}`}
+                  size={14}
+                  className={`opacity-0 transition-all duration-200 group-hover:opacity-100 ${
+                    isDropdownOpen ? "rotate-180 opacity-100!" : ""
+                  }`}
                 />
               </button>
             ) : (

--- a/src/components/sidebar/components/SidebarHeader.tsx
+++ b/src/components/sidebar/components/SidebarHeader.tsx
@@ -101,7 +101,7 @@ export const SidebarHeader = ({ isOpen }: SidebarHeaderProps) => {
                   icon={IconChevronDown}
                   size={14}
                   className={`opacity-0 transition-all duration-200 group-hover:opacity-100 ${
-                    isDropdownOpen ? "rotate-180 opacity-100!" : ""
+                    isDropdownOpen ? "rotate-180 opacity-100" : ""
                   }`}
                 />
               </button>

--- a/src/components/sidebar/components/SidebarHeader.tsx
+++ b/src/components/sidebar/components/SidebarHeader.tsx
@@ -3,6 +3,7 @@ import IconChevronDown from "@/assets/icons/arrow/ic_chevron_down.svg?react";
 import IconAddPlus from "@/assets/icons/edit/ic_add_plus.svg?react";
 import IconMenuBurger from "@/assets/icons/menu/ic_menu_burger.svg?react";
 import { Icon } from "@/components/common/Icon";
+import { TeamImage } from "@/components/common/TeamImage";
 import CreateTeamModal from "@/components/panel/CreateTeamModal";
 import { useCreateTeam } from "@/pages/home/hooks/useCreateTeam";
 import type { Team } from "@/types/team";
@@ -22,7 +23,11 @@ export const SidebarHeader = ({ isOpen }: SidebarHeaderProps) => {
 
   const { createTeam, isPending } = useCreateTeam({
     onSuccess: (result) => {
-      setCurrentTeam({ team_id: result.team_id, name: result.name });
+      setCurrentTeam({
+        team_id: result.team_id,
+        name: result.name,
+        team_image: result.team_image ?? null,
+      });
       setIsModalOpen(false);
     },
   });
@@ -82,7 +87,11 @@ export const SidebarHeader = ({ isOpen }: SidebarHeaderProps) => {
                 onClick={() => setIsDropdownOpen((prev) => !prev)}
                 className="flex cursor-pointer items-center gap-1"
               >
-                <div className="size-[18px] rounded-sm bg-gray-400" />
+                <TeamImage
+                  src={currentTeam?.team_image}
+                  alt={`${currentTeam?.name ?? "팀"} 이미지`}
+                  size={18}
+                />
                 <span className="typo-subtitle3 whitespace-nowrap text-black">
                   {currentTeam?.name ?? "팀 명"}
                 </span>

--- a/src/components/sidebar/components/SidebarHeader.tsx
+++ b/src/components/sidebar/components/SidebarHeader.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import IconChevronDown from "@/assets/icons/arrow/ic_chevron_down.svg?react";
 import IconAddPlus from "@/assets/icons/edit/ic_add_plus.svg?react";
 import IconMenuBurger from "@/assets/icons/menu/ic_menu_burger.svg?react";
 import { Icon } from "@/components/common/Icon";
 import { TeamImage } from "@/components/common/TeamImage";
 import CreateTeamModal from "@/components/panel/CreateTeamModal";
+import { createTeamRoute } from "@/constants/routes";
+import { useCurrentTeam } from "@/hooks/useCurrentTeam";
 import { useCreateTeam } from "@/pages/home/hooks/useCreateTeam";
 import type { Team } from "@/types/team";
 import { useTeams } from "../hooks/useTeams";
@@ -15,28 +18,20 @@ interface SidebarHeaderProps {
 }
 
 export const SidebarHeader = ({ isOpen }: SidebarHeaderProps) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { currentTeam } = useCurrentTeam();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [currentTeam, setCurrentTeam] = useState<Team | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { data: teams = [] } = useTeams();
 
   const { createTeam, isPending } = useCreateTeam({
     onSuccess: (result) => {
-      setCurrentTeam({
-        team_id: result.team_id,
-        name: result.name,
-        team_image: result.image_url ?? null,
-      });
       setIsModalOpen(false);
+      navigate(createTeamRoute(result.team_id));
     },
   });
-
-  useEffect(() => {
-    if (teams.length > 0 && !currentTeam) {
-      setCurrentTeam(teams[0]);
-    }
-  }, [teams, currentTeam]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -58,8 +53,13 @@ export const SidebarHeader = ({ isOpen }: SidebarHeaderProps) => {
   }, []);
 
   const handleSelectTeam = (team: Team) => {
-    setCurrentTeam(team);
     setIsDropdownOpen(false);
+
+    // 현재 경로에서 팀 부분 제거
+    const pathWithoutTeam = location.pathname.replace(/^\/team\/\d+/, "");
+
+    // 새 팀으로 동일한 페이지 이동
+    navigate(`/team/${team.team_id}${pathWithoutTeam}`);
   };
 
   const handleCreateTeam = () => {

--- a/src/components/sidebar/components/TeamListDropdown.tsx
+++ b/src/components/sidebar/components/TeamListDropdown.tsx
@@ -1,5 +1,6 @@
 import IconAddPlus from "@/assets/icons/edit/ic_add_plus.svg?react";
 import { Icon } from "@/components/common/Icon";
+import { TeamImage } from "@/components/common/TeamImage";
 import type { Team } from "@/types/team";
 
 interface TeamListDropdownProps {
@@ -26,7 +27,11 @@ export const TeamListDropdown = ({
             ${currentTeamId === team.team_id ? "bg-action-active text-text-brand-darker" : "text-text-primary"}
           `}
         >
-          <div className="size-5 shrink-0 rounded-sm bg-gray-400" />
+          <TeamImage
+            src={team.team_image}
+            alt={`${team.name} 이미지`}
+            size={20}
+          />
           <span className="typo-body5 truncate">{team.name}</span>
         </button>
       ))}

--- a/src/components/sidebar/hooks/useSidebarNavigation.ts
+++ b/src/components/sidebar/hooks/useSidebarNavigation.ts
@@ -2,12 +2,14 @@ import { isAxiosError } from "axios";
 import { useLocation, useNavigate } from "react-router-dom";
 import { logout } from "@/apis/auth";
 import { ROUTES } from "@/constants/routes";
+import { useCurrentTeam } from "@/hooks/useCurrentTeam";
 import { tokenStore } from "@/utils/tokenStore";
 import type { MenuItem } from "../types";
 
 export const useSidebarNavigation = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const { teamId } = useCurrentTeam();
 
   const handleMenuClick = async (item: MenuItem) => {
     if (item.id === "logout") {
@@ -24,15 +26,29 @@ export const useSidebarNavigation = () => {
       }
       return;
     }
-    if (item.path) {
-      navigate(item.path);
+
+    if (item.id === "settings") {
+      navigate("/settings");
+      return;
+    }
+
+    if (item.path && teamId) {
+      navigate(`/team/${teamId}${item.path}`);
     }
   };
 
   const isActive = (item: MenuItem) => {
     if (!item.path) return false;
-    if (item.path === "/") return location.pathname === "/";
-    return location.pathname.startsWith(item.path);
+
+    if (item.id === "settings") {
+      return location.pathname === "/settings";
+    }
+
+    // 팀 경로에서 패턴 매칭
+    if (item.path === "/") {
+      return /^\/team\/\d+$/.test(location.pathname);
+    }
+    return location.pathname.includes(item.path);
   };
 
   return { handleMenuClick, isActive };

--- a/src/components/sidebar/hooks/useSidebarNavigation.ts
+++ b/src/components/sidebar/hooks/useSidebarNavigation.ts
@@ -41,7 +41,7 @@ export const useSidebarNavigation = () => {
     if (!item.path) return false;
 
     if (item.id === "settings") {
-      return location.pathname === "/settings";
+      return location.pathname.endsWith("/settings");
     }
 
     // 팀 경로에서 패턴 매칭

--- a/src/constants/endpoint.ts
+++ b/src/constants/endpoint.ts
@@ -12,7 +12,7 @@ const ENDPOINT = {
     LOGOUT: `${API_BASE_URL}/api/auth/logout`,
   },
   TEAMS: {
-    LIST: `${API_BASE_URL}/api/teams`,
+    LIST: `${API_BASE_URL}/api/members/teams`,
     CREATE: `${API_BASE_URL}/api/teams`,
   },
   MEETINGS: {

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -2,9 +2,24 @@ export const ROUTES = {
   APP_ROOT: "/",
   SIGNUP: "/signup",
   LOGIN: "/login",
+  SETTINGS: "/settings",
+
+  // 팀 기반 라우트
+  TEAM_ROOT: "/team/:teamId",
+  TEAM_HOME: "/team/:teamId",
+  TEAM_DECISIONS: "/team/:teamId/decisions",
+  TEAM_MEETING: "/team/:teamId/meeting",
+  TEAM_MEETING_DETAIL: "/team/:teamId/meeting/:meetingId",
+  TEAM_GIT: "/team/:teamId/git",
+
+  // 레거시 라우트 (하위 호환성)
   DECISIONS: "/decisions",
   MEETING: "/meeting",
   MEETING_DETAIL: "/meeting/:meetingId",
   GIT: "/git",
-  SETTINGS: "/settings",
 } as const;
+
+// 헬퍼 함수: 팀 ID와 경로를 받아 완전한 URL 생성
+export const createTeamRoute = (teamId: number, path: string = "") => {
+  return `/team/${teamId}${path}`;
+};

--- a/src/hooks/useCurrentTeam.ts
+++ b/src/hooks/useCurrentTeam.ts
@@ -3,7 +3,7 @@ import { useTeams } from "@/components/sidebar/hooks/useTeams";
 
 export const useCurrentTeam = () => {
   const { teamId } = useParams<{ teamId: string }>();
-  const { data: teams } = useTeams();
+  const { data: teams, isLoading, isError } = useTeams();
 
   const teamIdNum = teamId ? Number(teamId) : null;
   const currentTeam = teams?.find((t) => t.team_id === teamIdNum) ?? null;
@@ -11,6 +11,7 @@ export const useCurrentTeam = () => {
   return {
     teamId: teamIdNum,
     currentTeam,
-    isLoading: !teams,
+    isLoading,
+    isError,
   };
 };

--- a/src/hooks/useCurrentTeam.ts
+++ b/src/hooks/useCurrentTeam.ts
@@ -1,0 +1,16 @@
+import { useParams } from "react-router-dom";
+import { useTeams } from "@/components/sidebar/hooks/useTeams";
+
+export const useCurrentTeam = () => {
+  const { teamId } = useParams<{ teamId: string }>();
+  const { data: teams } = useTeams();
+
+  const teamIdNum = teamId ? Number(teamId) : null;
+  const currentTeam = teams?.find((t) => t.team_id === teamIdNum) ?? null;
+
+  return {
+    teamId: teamIdNum,
+    currentTeam,
+    isLoading: !teams,
+  };
+};

--- a/src/layout/TeamLayout/index.tsx
+++ b/src/layout/TeamLayout/index.tsx
@@ -4,12 +4,22 @@ import AppLayout from "../AppLayout";
 
 const TeamLayout = () => {
   const { teamId } = useParams<{ teamId: string }>();
-  const { data: teams, isLoading } = useTeams();
+  const { data: teams, isLoading, isError } = useTeams();
 
   if (isLoading) {
     return (
       <div className="flex h-screen items-center justify-center">
         <div className="text-lg">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-lg text-red-500">
+          팀 목록을 불러오지 못했습니다.
+        </div>
       </div>
     );
   }

--- a/src/layout/TeamLayout/index.tsx
+++ b/src/layout/TeamLayout/index.tsx
@@ -1,0 +1,37 @@
+import { Navigate, Outlet, useParams } from "react-router-dom";
+import { useTeams } from "@/components/sidebar/hooks/useTeams";
+import AppLayout from "../AppLayout";
+
+const TeamLayout = () => {
+  const { teamId } = useParams<{ teamId: string }>();
+  const { data: teams, isLoading } = useTeams();
+
+  if (isLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-lg">로딩 중...</div>
+      </div>
+    );
+  }
+
+  const teamIdNum = Number(teamId);
+
+  // 팀이 없으면 온보딩 페이지로
+  if (!teams || teams.length === 0) {
+    return <Navigate to="/onboarding/create-team" replace />;
+  }
+
+  // 잘못된 teamId면 첫 번째 팀으로 리다이렉트
+  const isValidTeam = teams.some((team) => team.team_id === teamIdNum);
+  if (!isValidTeam) {
+    return <Navigate to={`/team/${teams[0].team_id}`} replace />;
+  }
+
+  return (
+    <AppLayout>
+      <Outlet />
+    </AppLayout>
+  );
+};
+
+export default TeamLayout;

--- a/src/pages/home/hooks/useCreateTeam.ts
+++ b/src/pages/home/hooks/useCreateTeam.ts
@@ -16,8 +16,8 @@ export const useCreateTeam = (options?: UseCreateTeamOptions) => {
 
   const mutation = useMutation({
     mutationFn: (payload: CreateTeamRequest) => createTeam(payload),
-    onSuccess: (result: CreateTeamResult) => {
-      queryClient.invalidateQueries({ queryKey: TEAMS_QUERY_KEY });
+    onSuccess: async (result: CreateTeamResult) => {
+      await queryClient.invalidateQueries({ queryKey: TEAMS_QUERY_KEY });
       options?.onSuccess?.(result);
     },
     onError: (error: unknown) => {

--- a/src/pages/home/hooks/useCreateTeam.ts
+++ b/src/pages/home/hooks/useCreateTeam.ts
@@ -15,7 +15,8 @@ export const useCreateTeam = (options?: UseCreateTeamOptions) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const mutation = useMutation({
-    mutationFn: ({ name }: { name: string }) => createTeam({ name }),
+    mutationFn: ({ name, image }: { name: string; image?: File }) =>
+      createTeam(name, image),
     onSuccess: (result: CreateTeamResult) => {
       queryClient.invalidateQueries({ queryKey: TEAMS_QUERY_KEY });
       options?.onSuccess?.(result);
@@ -33,9 +34,9 @@ export const useCreateTeam = (options?: UseCreateTeamOptions) => {
   });
 
   return {
-    createTeam: (name: string) => {
+    createTeam: (name: string, image?: File) => {
       setErrorMessage(null);
-      mutation.mutate({ name });
+      mutation.mutate({ name, image });
     },
     isPending: mutation.isPending,
     errorMessage,

--- a/src/pages/home/hooks/useCreateTeam.ts
+++ b/src/pages/home/hooks/useCreateTeam.ts
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { createTeam } from "@/apis/teams";
 import { TEAMS_QUERY_KEY } from "@/components/sidebar/hooks/useTeams";
 import type { ApiResponse } from "@/types/auth";
-import type { CreateTeamResult } from "@/types/team";
+import type { CreateTeamRequest, CreateTeamResult } from "@/types/team";
 
 interface UseCreateTeamOptions {
   onSuccess?: (result: CreateTeamResult) => void;
@@ -15,8 +15,7 @@ export const useCreateTeam = (options?: UseCreateTeamOptions) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const mutation = useMutation({
-    mutationFn: ({ name, image }: { name: string; image?: File }) =>
-      createTeam(name, image),
+    mutationFn: (payload: CreateTeamRequest) => createTeam(payload),
     onSuccess: (result: CreateTeamResult) => {
       queryClient.invalidateQueries({ queryKey: TEAMS_QUERY_KEY });
       options?.onSuccess?.(result);

--- a/src/pages/meeting/hooks/useCreateMeeting.ts
+++ b/src/pages/meeting/hooks/useCreateMeeting.ts
@@ -14,7 +14,7 @@ export const useCreateMeeting = (teamId: number | null) => {
 
   const mutation = useMutation({
     mutationFn: ({ name }: { name: string }) => {
-      if (!teamId) throw new Error("Team ID is required");
+      if (teamId == null) throw new Error("Team ID is required");
       return createMeeting(teamId, {
         name,
         startDateTime: new Date().toISOString(),

--- a/src/pages/meeting/hooks/useCreateMeeting.ts
+++ b/src/pages/meeting/hooks/useCreateMeeting.ts
@@ -7,23 +7,22 @@ import type { ApiResponse } from "@/types/auth";
 import type { CreateMeetingResult } from "@/types/meeting";
 import { MEETING_LIST_QUERY_KEY } from "./useMeetingList";
 
-// TODO: teamId를 로그인 응답/팀 컨텍스트에서 가져오도록 교체
-const TEMP_TEAM_ID = 3;
-
-export const useCreateMeeting = () => {
+export const useCreateMeeting = (teamId: number | null) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const mutation = useMutation({
-    mutationFn: ({ name }: { name: string }) =>
-      createMeeting(TEMP_TEAM_ID, {
+    mutationFn: ({ name }: { name: string }) => {
+      if (!teamId) throw new Error("Team ID is required");
+      return createMeeting(teamId, {
         name,
         startDateTime: new Date().toISOString(),
-      }),
+      });
+    },
     onSuccess: (result: CreateMeetingResult) => {
       queryClient.invalidateQueries({ queryKey: MEETING_LIST_QUERY_KEY });
-      navigate(`/meeting/${result.meeting_id}`, {
+      navigate(`/team/${teamId}/meeting/${result.meeting_id}`, {
         state: { name: result.name },
       });
     },

--- a/src/pages/meeting/hooks/useMeetingList.ts
+++ b/src/pages/meeting/hooks/useMeetingList.ts
@@ -2,20 +2,25 @@ import { useQuery } from "@tanstack/react-query";
 import { listMeetings } from "@/apis/meetings";
 import type { MeetingListItem } from "@/types/meeting";
 
-// TODO: teamId를 로그인 응답/팀 컨텍스트에서 가져오도록 교체
-const TEMP_TEAM_ID = 3;
-
 export const MEETING_LIST_QUERY_KEY = ["meetings"] as const;
 
-export const useMeetingList = () => {
+export const useMeetingList = (teamId: number | null) => {
   const ongoingQuery = useQuery<MeetingListItem[]>({
-    queryKey: [...MEETING_LIST_QUERY_KEY, TEMP_TEAM_ID, "ONGOING"],
-    queryFn: () => listMeetings(TEMP_TEAM_ID, "ONGOING"),
+    queryKey: [...MEETING_LIST_QUERY_KEY, teamId, "ONGOING"],
+    queryFn: () => {
+      if (!teamId) throw new Error("Team ID is required");
+      return listMeetings(teamId, "ONGOING");
+    },
+    enabled: !!teamId,
   });
 
   const completedQuery = useQuery<MeetingListItem[]>({
-    queryKey: [...MEETING_LIST_QUERY_KEY, TEMP_TEAM_ID, "COMPLETED"],
-    queryFn: () => listMeetings(TEMP_TEAM_ID, "COMPLETED"),
+    queryKey: [...MEETING_LIST_QUERY_KEY, teamId, "COMPLETED"],
+    queryFn: () => {
+      if (!teamId) throw new Error("Team ID is required");
+      return listMeetings(teamId, "COMPLETED");
+    },
+    enabled: !!teamId,
   });
 
   return {

--- a/src/pages/meeting/hooks/useMeetingList.ts
+++ b/src/pages/meeting/hooks/useMeetingList.ts
@@ -8,19 +8,19 @@ export const useMeetingList = (teamId: number | null) => {
   const ongoingQuery = useQuery<MeetingListItem[]>({
     queryKey: [...MEETING_LIST_QUERY_KEY, teamId, "ONGOING"],
     queryFn: () => {
-      if (!teamId) throw new Error("Team ID is required");
+      if (teamId == null) throw new Error("Team ID is required");
       return listMeetings(teamId, "ONGOING");
     },
-    enabled: !!teamId,
+    enabled: teamId != null,
   });
 
   const completedQuery = useQuery<MeetingListItem[]>({
     queryKey: [...MEETING_LIST_QUERY_KEY, teamId, "COMPLETED"],
     queryFn: () => {
-      if (!teamId) throw new Error("Team ID is required");
+      if (teamId == null) throw new Error("Team ID is required");
       return listMeetings(teamId, "COMPLETED");
     },
-    enabled: !!teamId,
+    enabled: teamId != null,
   });
 
   return {

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,8 +1,10 @@
 import type { RouteObject } from "react-router-dom";
 import { useRoutes } from "react-router-dom";
 import ProtectedRoute from "../components/auth/ProtectedRoute";
+import RootRedirect from "../components/routing/RootRedirect";
 import { ROUTES } from "../constants/routes";
 import AppLayout from "../layout/AppLayout";
+import TeamLayout from "../layout/TeamLayout";
 import {
   DecisionsPage,
   GitPage,
@@ -16,56 +18,49 @@ import {
 } from "../pages";
 
 const allRoutes: RouteObject[] = [
+  // 1. 루트 리다이렉트
   {
-    path: ROUTES.APP_ROOT,
+    path: "/",
     element: (
       <ProtectedRoute>
-        <AppLayout>
-          <HomePage />
-        </AppLayout>
+        <RootRedirect />
       </ProtectedRoute>
     ),
   },
+
+  // 2. 팀 기반 라우트 (nested)
   {
-    path: ROUTES.DECISIONS,
+    path: "/team/:teamId",
     element: (
       <ProtectedRoute>
-        <AppLayout>
-          <DecisionsPage />
-        </AppLayout>
+        <TeamLayout />
       </ProtectedRoute>
     ),
+    children: [
+      {
+        index: true,
+        element: <HomePage />,
+      },
+      {
+        path: "decisions",
+        element: <DecisionsPage />,
+      },
+      {
+        path: "meeting",
+        element: <MeetingPage />,
+      },
+      {
+        path: "meeting/:meetingId",
+        element: <InProgressPage />,
+      },
+      {
+        path: "git",
+        element: <GitPage />,
+      },
+    ],
   },
-  {
-    path: ROUTES.MEETING,
-    element: (
-      <ProtectedRoute>
-        <AppLayout>
-          <MeetingPage />
-        </AppLayout>
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: ROUTES.MEETING_DETAIL,
-    element: (
-      <ProtectedRoute>
-        <AppLayout>
-          <InProgressPage />
-        </AppLayout>
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: ROUTES.GIT,
-    element: (
-      <ProtectedRoute>
-        <AppLayout>
-          <GitPage />
-        </AppLayout>
-      </ProtectedRoute>
-    ),
-  },
+
+  // 3. 팀 독립적 라우트
   {
     path: ROUTES.SETTINGS,
     element: (
@@ -76,6 +71,8 @@ const allRoutes: RouteObject[] = [
       </ProtectedRoute>
     ),
   },
+
+  // 4. 인증 라우트
   {
     path: ROUTES.LOGIN,
     element: <LoginPage />,
@@ -84,6 +81,8 @@ const allRoutes: RouteObject[] = [
     path: ROUTES.SIGNUP,
     element: <SignupPage />,
   },
+
+  // 5. 404
   {
     path: "/*",
     element: <NotFound />,

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -1,7 +1,6 @@
 export interface CreateTeamRequest {
   name: string;
-  // TODO: 백엔드 이미지 업로드 지원 시 추가
-  // image?: File;
+  image?: File;
 }
 
 export interface CreateTeamResult {

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -8,6 +8,7 @@ export interface CreateTeamResult {
   team_id: number;
   name: string;
   team_image?: string | null;
+  image_url?: string | null;
 }
 
 export interface Team {

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -7,9 +7,11 @@ export interface CreateTeamRequest {
 export interface CreateTeamResult {
   team_id: number;
   name: string;
+  team_image?: string | null;
 }
 
 export interface Team {
   team_id: number;
   name: string;
+  team_image: string | null;
 }


### PR DESCRIPTION
<!-- PR 제목 예시-> [Feat]: 소셜 로그인 기능 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
팀 조회 API 연동 및 생성/라우팅 구조 개선

## 📄 작업 내용
- 소속 팀 목록 조회 api 연동
- 팀 생성에 이미지 추가
- 팀 목록 조회 ui 수정
- 팀 기반 라우트 추가


## 📌 관련 이수
- close #18 

## 📷 UI 스크린샷 (해당 시)
<!-- 전/후 비교 이미지 등 첨부 -->
<img width="252" height="355" alt="Screenshot 2026-04-16 at 4 36 02 PM" src="https://github.com/user-attachments/assets/fd995ba2-d89d-478b-9ba3-ad331ac8f95d" />
<img width="293" height="369" alt="Screenshot 2026-04-16 at 4 36 12 PM" src="https://github.com/user-attachments/assets/c066fd5f-46ca-43ba-a1e7-9ce834e1378d" />

