### PR TITLE
[Fix]: 회의 transcript 화자 이름 실제 닉네임으로 표시

### DIFF
--- a/src/pages/meeting/InProgressPage.tsx
+++ b/src/pages/meeting/InProgressPage.tsx
@@ -1,4 +1,6 @@
 import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { decodeAccessToken } from "@/utils/jwt";
+import { tokenStore } from "@/utils/tokenStore";
 import LiveTranscriptPanel from "./components/LiveTranscriptPanel";
 import MeetingControls from "./components/MeetingControls";
 import MeetingHeader from "./components/MeetingHeader";
@@ -49,6 +51,13 @@ const InProgressPage = () => {
   const startedAt = parseStartTimestamp(meetingDetail?.start_date_time);
   const elapsed = useElapsedTime(startedAt);
 
+  const accessToken = tokenStore.getToken();
+  const myMemberId = accessToken
+    ? (decodeAccessToken(accessToken)?.memberId ?? null)
+    : null;
+  const myName =
+    meetingDetail?.members.find((m) => m.member_id === myMemberId)?.name ?? "";
+
   const {
     participants,
     isWsConnected,
@@ -63,7 +72,7 @@ const InProgressPage = () => {
     setAudioOutputEnabled,
   } = useMeetingRoom({
     meetingId,
-    displayName: "나",
+    displayName: myName,
   });
 
   const { handleInterim, handleFinal, mergeTranscripts, mergeInterim } =
@@ -88,7 +97,9 @@ const InProgressPage = () => {
   const displayParticipants =
     participants.length > 0
       ? participants
-      : [{ id: "self", name: "나", isSelf: true }];
+      : myName && myMemberId != null
+        ? [{ id: String(myMemberId), name: myName, isSelf: true }]
+        : [];
 
   const handleEnd = () => {
     if (meetingId != null) endMeeting(meetingId);

--- a/src/pages/meeting/hooks/useMeetingSignaling.ts
+++ b/src/pages/meeting/hooks/useMeetingSignaling.ts
@@ -59,6 +59,7 @@ export const useMeetingSignaling = ({
 
   useEffect(() => {
     if (meetingId == null) return;
+    if (!displayName) return;
 
     const accessToken = tokenStore.getToken();
     if (!accessToken) {

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,0 +1,17 @@
+export interface AccessTokenPayload {
+  memberId: number;
+  role: string;
+  iat: number;
+  exp: number;
+}
+
+export const decodeAccessToken = (token: string): AccessTokenPayload | null => {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    const json = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
+    return JSON.parse(json) as AccessTokenPayload;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
<!-- PR 제목 예시-> [Feat]: 소셜 로그인 기능 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
`InProgressPage` 에서 `displayName` 이 `"나"` 로 하드코딩되어, WS signaling 의 `name` query 로 그대로 백엔드에 전송되고 모든 참가자에게 화자 이름이 "나" 로 broadcast 되던 문제를 수정

## 📄 작업 내용
- 회의 transcript 화자 이름 실제 닉네임으로 표시

## 📌 관련 이슈
- close #30 
