### PR TITLE
[Feat]: 회의 삭제 기능 구현 

### DIFF
--- a/src/apis/meetings.ts
+++ b/src/apis/meetings.ts
@@ -3,6 +3,7 @@ import type { ApiResponse } from "@/types/auth";
 import type {
   CreateMeetingRequest,
   CreateMeetingResult,
+  DeleteMeetingResult,
   EndMeetingResult,
   MeetingAnalysis,
   MeetingAudio,
@@ -119,6 +120,19 @@ export const endMeeting = async (
     undefined,
     { data: ApiResponse<EndMeetingResult> }
   >(ENDPOINT.MEETINGS.END(meetingId));
+  if (!data.isSuccess) {
+    throw new Error(data.message);
+  }
+  return data.result;
+};
+
+export const deleteMeeting = async (
+  meetingId: number,
+): Promise<DeleteMeetingResult> => {
+  const { data } = await http.delete<
+    unknown,
+    { data: ApiResponse<DeleteMeetingResult> }
+  >(ENDPOINT.MEETINGS.DELETE(meetingId));
   if (!data.isSuccess) {
     throw new Error(data.message);
   }

--- a/src/assets/icons/edit/ic_edit_pen.svg
+++ b/src/assets/icons/edit/ic_edit_pen.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 20H21"/>
+  <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/>
+</svg>

--- a/src/assets/icons/edit/ic_trash.svg
+++ b/src/assets/icons/edit/ic_trash.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 6H21"/>
+  <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+  <path d="M10 11V17"/>
+  <path d="M14 11V17"/>
+</svg>

--- a/src/constants/endpoint.ts
+++ b/src/constants/endpoint.ts
@@ -24,6 +24,7 @@ const ENDPOINT = {
     CREATE: (teamId: number) => `${API_BASE_URL}/api/teams/${teamId}/meetings`,
     LIST: (teamId: number) => `${API_BASE_URL}/api/teams/${teamId}/meetings`,
     DETAIL: (meetingId: number) => `${API_BASE_URL}/api/meetings/${meetingId}`,
+    DELETE: (meetingId: number) => `${API_BASE_URL}/api/meetings/${meetingId}`,
     RTC_TOKEN: (meetingId: number) =>
       `${API_BASE_URL}/api/meetings/${meetingId}/rtc-token`,
     END: (meetingId: number) => `${API_BASE_URL}/api/meetings/${meetingId}/end`,

--- a/src/pages/meeting/CompletedPage.tsx
+++ b/src/pages/meeting/CompletedPage.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { useParams } from "react-router-dom";
+import Modal from "@/components/common/Modal";
 import type {
   MeetingAnalysis,
   MeetingHistory,
@@ -8,6 +10,7 @@ import AudioPlayerBar from "./components/AudioPlayerBar";
 import CompletedMeetingHeader from "./components/CompletedMeetingHeader";
 import CompletedTranscript from "./components/CompletedTranscript";
 import CompletedInfoPanels from "./components/info-panels/CompletedInfoPanels";
+import { useDeleteMeeting } from "./hooks/useDeleteMeeting";
 import { useMeetingAnalysis } from "./hooks/useMeetingAnalysis";
 import { useMeetingAudio } from "./hooks/useMeetingAudio";
 import { useMeetingDetail } from "./hooks/useMeetingDetail";
@@ -100,6 +103,12 @@ const CompletedPage = () => {
   const { data: history } = useMeetingHistory(meetingId);
   const { data: analysis } = useMeetingAnalysis(meetingId);
   const { data: audio } = useMeetingAudio(meetingId);
+  const {
+    deleteMeeting,
+    isPending: isDeleting,
+    errorMessage: deleteError,
+  } = useDeleteMeeting();
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const name = detail?.name ?? "";
   const startText = formatStartText(detail?.start_date_time);
@@ -125,6 +134,10 @@ const CompletedPage = () => {
             durationText={durationText}
             memberCount={memberCount}
             members={members}
+            onDeleteClick={
+              meetingId != null ? () => setIsDeleteModalOpen(true) : undefined
+            }
+            isDeleting={isDeleting}
           />
           <div className="h-px w-full shrink-0 bg-(--color-border-divider)" />
           <CompletedTranscript items={transcript} />
@@ -138,6 +151,25 @@ const CompletedPage = () => {
 
         <CompletedInfoPanels panels={panels} isAnalyzing={isAnalyzing} />
       </div>
+      {isDeleteModalOpen && meetingId != null && (
+        <Modal
+          title="회의를 삭제하시겠습니까?"
+          onClose={() => !isDeleting && setIsDeleteModalOpen(false)}
+          primaryLabel={isDeleting ? "삭제 중..." : "삭제"}
+          onPrimaryClick={() => deleteMeeting(meetingId)}
+          isPrimaryDisabled={isDeleting}
+        >
+          <div className="flex flex-col gap-2">
+            <p className="typo-body4 text-(--color-text-secondary)">
+              회의 참여자, 대화 기록, 결정사항, 분석 데이터가 모두 삭제되며
+              복구할 수 없습니다.
+            </p>
+            {deleteError && (
+              <p className="typo-caption text-red-500">{deleteError}</p>
+            )}
+          </div>
+        </Modal>
+      )}
     </div>
   );
 };

--- a/src/pages/meeting/components/CompletedMeetingHeader.tsx
+++ b/src/pages/meeting/components/CompletedMeetingHeader.tsx
@@ -7,6 +7,8 @@ interface CompletedMeetingHeaderProps {
   durationText: string;
   memberCount: number;
   members: { name: string; profile_image: string | null }[];
+  onDeleteClick?: () => void;
+  isDeleting?: boolean;
 }
 
 const EditPenIcon = () => (
@@ -26,12 +28,34 @@ const EditPenIcon = () => (
   </svg>
 );
 
+const TrashIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M3 6h18" />
+    <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+    <path d="M10 11v6" />
+    <path d="M14 11v6" />
+  </svg>
+);
+
 const CompletedMeetingHeader = ({
   name,
   startText,
   durationText,
   memberCount,
   members,
+  onDeleteClick,
+  isDeleting = false,
 }: CompletedMeetingHeaderProps) => {
   return (
     <div className="flex flex-col gap-3">
@@ -42,13 +66,26 @@ const CompletedMeetingHeader = ({
             {startText} {durationText} {memberCount}명
           </span>
         </div>
-        <button
-          type="button"
-          className="cursor-pointer text-(--color-text-tertiary) hover:text-(--color-text-secondary)"
-          aria-label="회의 정보 수정"
-        >
-          <EditPenIcon />
-        </button>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            className="cursor-pointer text-(--color-text-tertiary) hover:text-(--color-text-secondary)"
+            aria-label="회의 정보 수정"
+          >
+            <EditPenIcon />
+          </button>
+          {onDeleteClick && (
+            <button
+              type="button"
+              className="cursor-pointer text-(--color-text-tertiary) hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+              onClick={onDeleteClick}
+              disabled={isDeleting}
+              aria-label="회의 삭제"
+            >
+              <TrashIcon />
+            </button>
+          )}
+        </div>
       </div>
 
       <div className="flex flex-col gap-2">

--- a/src/pages/meeting/components/CompletedMeetingHeader.tsx
+++ b/src/pages/meeting/components/CompletedMeetingHeader.tsx
@@ -1,3 +1,5 @@
+import IconEditPen from "@/assets/icons/edit/ic_edit_pen.svg?react";
+import IconTrash from "@/assets/icons/edit/ic_trash.svg?react";
 import IconCircleUser from "@/assets/icons/user/ic_circle_user.svg?react";
 import { Icon } from "@/components/common/Icon";
 
@@ -10,43 +12,6 @@ interface CompletedMeetingHeaderProps {
   onDeleteClick?: () => void;
   isDeleting?: boolean;
 }
-
-const EditPenIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M12 20h9" />
-    <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
-  </svg>
-);
-
-const TrashIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M3 6h18" />
-    <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-    <path d="M10 11v6" />
-    <path d="M14 11v6" />
-  </svg>
-);
 
 const CompletedMeetingHeader = ({
   name,
@@ -72,7 +37,7 @@ const CompletedMeetingHeader = ({
             className="cursor-pointer text-(--color-text-tertiary) hover:text-(--color-text-secondary)"
             aria-label="회의 정보 수정"
           >
-            <EditPenIcon />
+            <Icon icon={IconEditPen} size={16} />
           </button>
           {onDeleteClick && (
             <button
@@ -82,7 +47,7 @@ const CompletedMeetingHeader = ({
               disabled={isDeleting}
               aria-label="회의 삭제"
             >
-              <TrashIcon />
+              <Icon icon={IconTrash} size={16} />
             </button>
           )}
         </div>

--- a/src/pages/meeting/hooks/useDeleteMeeting.ts
+++ b/src/pages/meeting/hooks/useDeleteMeeting.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { deleteMeeting } from "@/apis/meetings";
+import type { ApiResponse } from "@/types/auth";
+import { MEETING_LIST_QUERY_KEY } from "./useMeetingList";
+
+/**
+ * 회의 삭제 처리.
+ * - 성공: 회의 목록 캐시 무효화 후 홈("/")으로 이동
+ * - 실패: 에러 메시지를 hook에서 노출
+ */
+export const useDeleteMeeting = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: (id: number) => deleteMeeting(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: MEETING_LIST_QUERY_KEY });
+      navigate("/");
+    },
+    onError: (err: unknown) => {
+      if (isAxiosError<ApiResponse<unknown>>(err)) {
+        setErrorMessage(
+          err.response?.data?.message ?? "회의 삭제에 실패했습니다.",
+        );
+        return;
+      }
+      setErrorMessage("회의 삭제에 실패했습니다.");
+    },
+  });
+
+  return {
+    deleteMeeting: (id: number) => {
+      setErrorMessage(null);
+      mutation.mutate(id);
+    },
+    isPending: mutation.isPending,
+    errorMessage,
+  };
+};

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -15,6 +15,11 @@ export interface EndMeetingResult {
   end_date_time: string;
 }
 
+export interface DeleteMeetingResult {
+  meeting_id: number;
+  is_removed: boolean;
+}
+
 export type MeetingStatus = "ONGOING" | "COMPLETED";
 
 export interface MeetingListItem {


### PR DESCRIPTION
<!-- PR 제목 예시-> [Feat]: 소셜 로그인 기능 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
완료된 회의에 한해서 사용자가 회의를 삭제할 수 있도록, 
완료된 회의 페이지의 헤더 우측에 쓰레기 아이콘 추가 및 회의 삭제 api 연동

## 📄 작업 내용
- 회의 삭제 기능 구현 

## 📌 관련 이슈
- close #49 

## 📷 UI 스크린샷 (해당 시)
<!-- 전/후 비교 이미지 등 첨부 -->

<img width="729" height="235" alt="image" src="https://github.com/user-attachments/assets/23119f4a-080c-4734-9d5c-398adf372281" />

<img width="1921" height="1141" alt="image" src="https://github.com/user-attachments/assets/045f0744-207c-47a8-b0d1-785a1f4e5a75" />

 