### PR TITLE
[Feat]: 팀 제거 기능 구현

### DIFF
--- a/src/apis/teams.ts
+++ b/src/apis/teams.ts
@@ -4,6 +4,7 @@ import type { ApiResponse } from "@/types/auth";
 import type {
   CreateTeamRequest,
   CreateTeamResult,
+  DeleteTeamResult,
   InviteTeamMemberRequest,
   InviteTeamMemberResult,
   Team,
@@ -40,6 +41,21 @@ export const createTeam = async (
       "Content-Type": "multipart/form-data",
     },
   });
+
+  if (!data.isSuccess) {
+    throw new Error(data.message);
+  }
+
+  return data.result;
+};
+
+export const deleteTeam = async (
+  teamId: number,
+): Promise<DeleteTeamResult> => {
+  const { data } = await http.delete<
+    unknown,
+    AxiosResponse<ApiResponse<DeleteTeamResult>>
+  >(ENDPOINT.TEAMS.DELETE(teamId));
 
   if (!data.isSuccess) {
     throw new Error(data.message);

--- a/src/components/panel/index.tsx
+++ b/src/components/panel/index.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useLocation } from "react-router-dom";
 import DecisionPanel from "./decision/DecisionPanel";
 import MeetingPanel from "./meeting/MeetingPanel";
@@ -6,22 +7,20 @@ import RepositoryPanel from "./repository/RepositoryPanel";
 const Panel = () => {
   const { pathname } = useLocation();
 
-  const renderContent = () => {
-    if (/\/decisions(\/|$)/.test(pathname)) {
-      return <DecisionPanel />;
-    }
-    if (/\/meeting(\/|$)/.test(pathname)) {
-      return <MeetingPanel />;
-    }
-    if (/\/git(\/|$)/.test(pathname)) {
-      return <RepositoryPanel />;
-    }
-    return null;
-  };
+  let content: ReactNode = null;
+  if (/\/decisions(\/|$)/.test(pathname)) {
+    content = <DecisionPanel />;
+  } else if (/\/meeting(\/|$)/.test(pathname)) {
+    content = <MeetingPanel />;
+  } else if (/\/git(\/|$)/.test(pathname)) {
+    content = <RepositoryPanel />;
+  }
+
+  if (!content) return null;
 
   return (
     <aside className="flex h-screen w-70 shrink-0 flex-col gap-4 overflow-hidden border-r border-solid border-(--color-border-default) bg-(--color-bg-surface) pt-10 pb-8 shadow-[0px_0px_2px_0px_rgba(40,41,61,0.04),0px_4px_8px_0px_rgba(96,97,112,0.16)]">
-      {renderContent()}
+      {content}
     </aside>
   );
 };

--- a/src/components/sidebar/hooks/useSidebarNavigation.ts
+++ b/src/components/sidebar/hooks/useSidebarNavigation.ts
@@ -27,11 +27,6 @@ export const useSidebarNavigation = () => {
       return;
     }
 
-    if (item.id === "settings") {
-      navigate("/settings");
-      return;
-    }
-
     if (item.path && teamId) {
       navigate(`/team/${teamId}${item.path}`);
     }
@@ -39,10 +34,6 @@ export const useSidebarNavigation = () => {
 
   const isActive = (item: MenuItem) => {
     if (!item.path) return false;
-
-    if (item.id === "settings") {
-      return location.pathname.endsWith("/settings");
-    }
 
     // 팀 경로에서 패턴 매칭
     if (item.path === "/") {

--- a/src/constants/endpoint.ts
+++ b/src/constants/endpoint.ts
@@ -14,6 +14,7 @@ const ENDPOINT = {
   TEAMS: {
     LIST: `${API_BASE_URL}/api/members/teams`,
     CREATE: `${API_BASE_URL}/api/teams`,
+    DELETE: (teamId: number) => `${API_BASE_URL}/api/teams/${teamId}`,
     INVITE: (teamId: number) =>
       `${API_BASE_URL}/api/teams/${teamId}/invitations`,
   },

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -2,7 +2,6 @@ export const ROUTES = {
   APP_ROOT: "/",
   SIGNUP: "/signup",
   LOGIN: "/login",
-  SETTINGS: "/settings",
 
   // 팀 기반 라우트
   TEAM_ROOT: "/team/:teamId",
@@ -11,6 +10,7 @@ export const ROUTES = {
   TEAM_MEETING: "/team/:teamId/meeting",
   TEAM_MEETING_DETAIL: "/team/:teamId/meeting/:meetingId",
   TEAM_GIT: "/team/:teamId/git",
+  TEAM_SETTINGS: "/team/:teamId/settings",
 
   // 레거시 라우트 (하위 호환성)
   DECISIONS: "/decisions",

--- a/src/pages/settings/hooks/useDeleteTeam.ts
+++ b/src/pages/settings/hooks/useDeleteTeam.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { deleteTeam } from "@/apis/teams";
+import { TEAMS_QUERY_KEY } from "@/components/sidebar/hooks/useTeams";
+import type { ApiResponse } from "@/types/auth";
+
+/**
+ * 팀 삭제 처리.
+ * - 성공: 팀 목록 캐시 무효화 후 홈("/")으로 이동 (RootRedirect가 다른 팀/온보딩으로 분기)
+ * - 실패: 에러 메시지를 hook에서 노출
+ */
+export const useDeleteTeam = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: (id: number) => deleteTeam(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: TEAMS_QUERY_KEY });
+      navigate("/");
+    },
+    onError: (err: unknown) => {
+      if (isAxiosError<ApiResponse<unknown>>(err)) {
+        setErrorMessage(
+          err.response?.data?.message ?? "팀 삭제에 실패했습니다.",
+        );
+        return;
+      }
+      setErrorMessage("팀 삭제에 실패했습니다.");
+    },
+  });
+
+  return {
+    deleteTeam: (id: number) => {
+      setErrorMessage(null);
+      mutation.mutate(id);
+    },
+    isPending: mutation.isPending,
+    errorMessage,
+  };
+};

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,9 +1,73 @@
-function SettingsPage() {
+import { useState } from "react";
+import Modal from "@/components/common/Modal";
+import { useCurrentTeam } from "@/hooks/useCurrentTeam";
+import { useDeleteTeam } from "./hooks/useDeleteTeam";
+
+const SettingsPage = () => {
+  const { teamId, currentTeam, isLoading } = useCurrentTeam();
+  const {
+    deleteTeam,
+    isPending: isDeleting,
+    errorMessage: deleteError,
+  } = useDeleteTeam();
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
   return (
-    <div>
-      <h1>설정</h1>
+    <div className="flex h-full flex-col gap-6 py-10">
+      <header className="flex flex-col gap-1">
+        <h1 className="typo-h4 text-(--color-text-primary)">설정</h1>
+        <p className="typo-body6 text-(--color-text-tertiary)">
+          팀 정보를 관리합니다.
+        </p>
+      </header>
+
+      <section className="flex flex-col gap-3 rounded-2xl border border-(--color-border-default) bg-(--color-bg-surface) px-6 py-5">
+        <h2 className="typo-subtitle3 text-(--color-text-primary)">팀 정보</h2>
+        <dl className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <dt className="typo-body6 text-(--color-text-tertiary) w-20">
+              팀 이름
+            </dt>
+            <dd className="typo-body4 text-(--color-text-primary)">
+              {isLoading ? "불러오는 중..." : (currentTeam?.name ?? "-")}
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <div>
+        <button
+          type="button"
+          className="typo-button-md cursor-pointer rounded-xl border border-red-300 bg-white px-5 py-2.5 text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={teamId == null || isDeleting}
+          onClick={() => setIsDeleteModalOpen(true)}
+        >
+          팀 삭제
+        </button>
+      </div>
+
+      {isDeleteModalOpen && teamId != null && (
+        <Modal
+          title="팀을 삭제하시겠습니까?"
+          onClose={() => !isDeleting && setIsDeleteModalOpen(false)}
+          primaryLabel={isDeleting ? "삭제 중..." : "삭제"}
+          onPrimaryClick={() => deleteTeam(teamId)}
+          isPrimaryDisabled={isDeleting}
+        >
+          <div className="flex flex-col gap-2">
+            <p className="typo-body4 text-(--color-text-secondary)">
+              {currentTeam?.name
+                ? `"${currentTeam.name}" 팀의 팀원, 회의, 저장소 정보가 모두 삭제되며 복구할 수 없습니다.`
+                : "팀의 팀원, 회의, 저장소 정보가 모두 삭제되며 복구할 수 없습니다."}
+            </p>
+            {deleteError && (
+              <p className="typo-caption text-red-500">{deleteError}</p>
+            )}
+          </div>
+        </Modal>
+      )}
     </div>
   );
-}
+};
 
 export default SettingsPage;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -3,7 +3,6 @@ import { useRoutes } from "react-router-dom";
 import ProtectedRoute from "../components/auth/ProtectedRoute";
 import RootRedirect from "../components/routing/RootRedirect";
 import { ROUTES } from "../constants/routes";
-import AppLayout from "../layout/AppLayout";
 import TeamLayout from "../layout/TeamLayout";
 import {
   DecisionsPage,
@@ -57,19 +56,11 @@ const allRoutes: RouteObject[] = [
         path: "git",
         element: <GitPage />,
       },
+      {
+        path: "settings",
+        element: <SettingsPage />,
+      },
     ],
-  },
-
-  // 3. 팀 독립적 라우트
-  {
-    path: ROUTES.SETTINGS,
-    element: (
-      <ProtectedRoute>
-        <AppLayout>
-          <SettingsPage />
-        </AppLayout>
-      </ProtectedRoute>
-    ),
   },
 
   // 4. 인증 라우트

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -24,3 +24,7 @@ export interface InviteTeamMemberResult {
   team_id: number;
   member_email: string;
 }
+
+export interface DeleteTeamResult {
+  is_removed: boolean;
+}


### PR DESCRIPTION
<!-- PR 제목 예시-> [Feat]: 소셜 로그인 기능 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
팀 제거 기능 구현

## 📄 작업 내용
- 홈 및 설정 페이지에서 패널 렌더링 하지 않도록 수정
- 팀별 설정 페이지에 팀 삭제 버튼 추가
- 팀 삭제 api 연동  


## 📌 관련 이슈
- close #50 

## 📷 UI 스크린샷 (해당 시)
<!-- 전/후 비교 이미지 등 첨부 -->
<img width="3420" height="1744" alt="image" src="https://github.com/user-attachments/assets/01755a91-202e-46b5-ba84-abd90b2faf08" />

<img width="3420" height="1744" alt="image" src="https://github.com/user-attachments/assets/25fa5ff8-0a1a-4ef2-a24e-344dd02be105" />

