### PR TITLE
[Feat]: 결정사항 페이지 ui 구현

### DIFF
--- a/src/layout/AppLayout/index.tsx
+++ b/src/layout/AppLayout/index.tsx
@@ -2,12 +2,18 @@ import type React from "react";
 import Panel from "@/components/panel";
 import Sidebar from "@/components/sidebar";
 
+const APP_BACKGROUND =
+  "linear-gradient(-19.8deg, rgba(208,240,244,0.5) 10.78%, rgba(232,228,248,0.5) 42.16%, rgba(216,228,252,0.5) 89.22%), linear-gradient(#ffffff,#ffffff)";
+
 const AppLayout = (props: { children?: React.ReactNode }) => {
   return (
     <div className="flex h-screen">
       <Sidebar />
       <Panel />
-      <main className="flex-1 overflow-auto px-20 3xl:px-50">
+      <main
+        className="flex-1 overflow-auto px-20 3xl:px-50"
+        style={{ backgroundImage: APP_BACKGROUND }}
+      >
         {props.children}
       </main>
     </div>

--- a/src/pages/decisions/DecisionDetailPage.tsx
+++ b/src/pages/decisions/DecisionDetailPage.tsx
@@ -1,0 +1,49 @@
+import type { DecisionDetailViewModel } from "@/types/decision";
+import ApplicationStatusCard from "./components/ApplicationStatusCard";
+import CommitTableCard from "./components/CommitTableCard";
+import ContextCard from "./components/ContextCard";
+import DecisionHeader from "./components/DecisionHeader";
+import ReasonsCard from "./components/ReasonsCard";
+import TimelineCard from "./components/TimelineCard";
+
+interface DecisionDetailPageProps {
+  vm: DecisionDetailViewModel;
+}
+
+const DecisionDetailPage = ({ vm }: DecisionDetailPageProps) => {
+  return (
+    <div className="-mx-20 flex h-full flex-col gap-7 overflow-y-auto p-6 lg:p-10 2xl:p-15 3xl:-mx-50">
+      <DecisionHeader
+        name={vm.detail.name}
+        confidence={vm.confidence}
+        meta={vm.meta}
+      />
+
+      <div className="flex min-h-0 flex-1 flex-col gap-5">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+          <TimelineCard items={vm.detail.decision_timelines} />
+          <ReasonsCard
+            reasons={vm.detail.decision_reasons}
+            count={vm.detail.decision_reason_count}
+          />
+          <ApplicationStatusCard commits={vm.applied_commits} />
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col items-stretch gap-5 lg:flex-row">
+          <ContextCard
+            messages={vm.detail.decision_contexts}
+            className="w-full lg:w-2/5 lg:min-w-90 lg:max-w-120"
+          />
+          <CommitTableCard
+            recommendedCommits={vm.recommended_commits}
+            linkedCommits={vm.linked_commits}
+            footerStats={vm.footer_stats}
+            className="w-full min-w-0 flex-1"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DecisionDetailPage;

--- a/src/pages/decisions/DecisionsRoutePage.tsx
+++ b/src/pages/decisions/DecisionsRoutePage.tsx
@@ -1,0 +1,24 @@
+import { useParams } from "react-router-dom";
+import { parseRouteId } from "@/utils/parseRouteId";
+import DecisionDetailPage from "./DecisionDetailPage";
+import DecisionsPage from "./index";
+import { getMockDecisionDetail } from "./mocks";
+
+const DecisionsRoutePage = () => {
+  const { decisionId: decisionIdParam, applicationId: applicationIdParam } =
+    useParams<{ decisionId: string; applicationId: string }>();
+  const decisionId = parseRouteId(decisionIdParam);
+  const applicationId = parseRouteId(applicationIdParam);
+
+  if (decisionId == null || applicationId == null) {
+    return <DecisionsPage />;
+  }
+
+  // TODO: API 연동 시 useDecisionDetail(decisionId) +
+  // useDecisionApplication(applicationId) 로 교체
+  const vm = getMockDecisionDetail(decisionId, applicationId);
+
+  return <DecisionDetailPage vm={vm} />;
+};
+
+export default DecisionsRoutePage;

--- a/src/pages/decisions/components/ApplicationStatusCard.tsx
+++ b/src/pages/decisions/components/ApplicationStatusCard.tsx
@@ -1,0 +1,48 @@
+import IconCheckboxCheck from "@/assets/icons/warning/ic_checkbox_check.svg?react";
+import { Icon } from "@/components/common/Icon";
+import type { DecisionApplicationDetail } from "@/types/decision";
+import GlassCard from "./GlassCard";
+
+interface ApplicationStatusCardProps {
+  commits: DecisionApplicationDetail[];
+}
+
+const CommitHashBadge = ({ hash }: { hash: string }) => (
+  <span className="inline-flex items-center justify-center rounded bg-[#f5e5ff] px-3 py-0.5 font-mono text-[10px] leading-3.75 text-purple-700">
+    {hash}
+  </span>
+);
+
+const ApplicationStatusCard = ({ commits }: ApplicationStatusCardProps) => {
+  return (
+    <GlassCard className="h-51 gap-4 overflow-hidden px-4 py-5">
+      <div className="flex items-center gap-1">
+        <Icon
+          icon={IconCheckboxCheck}
+          size={16}
+          className="text-(--color-text-primary)"
+        />
+        <p className="typo-body6 text-(--color-text-primary)">적용현황</p>
+        <p className="typo-caption2 text-(--color-text-secondary)">
+          ({commits.length})
+        </p>
+      </div>
+
+      <ul className="flex flex-1 flex-col gap-4 overflow-y-auto">
+        {commits.map((c) => (
+          <li
+            key={`${c.application_id}-${c.commit_id}`}
+            className="flex items-center gap-2"
+          >
+            <CommitHashBadge hash={c.commit_hash} />
+            <p className="typo-body5 flex-1 truncate text-(--color-text-primary)">
+              {c.message}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </GlassCard>
+  );
+};
+
+export default ApplicationStatusCard;

--- a/src/pages/decisions/components/CommitTableCard.tsx
+++ b/src/pages/decisions/components/CommitTableCard.tsx
@@ -1,0 +1,202 @@
+import { useState } from "react";
+import IconArrowsReload from "@/assets/icons/arrow/ic_arrows_reload.svg?react";
+import IconAddPlus from "@/assets/icons/edit/ic_add_plus.svg?react";
+import { Icon } from "@/components/common/Icon";
+import type {
+  CommitTab,
+  DecisionFooterStats,
+  RecommendedCommit,
+} from "@/types/decision";
+import GlassCard from "./GlassCard";
+
+interface CommitTableCardProps {
+  recommendedCommits: RecommendedCommit[];
+  linkedCommits: RecommendedCommit[];
+  footerStats: DecisionFooterStats;
+  className?: string;
+}
+
+const CommitHashBadge = ({ hash }: { hash: string }) => (
+  <span className="inline-flex items-center justify-center rounded bg-[#f5e5ff] px-3 py-0.5 font-mono text-[10px] leading-3.75 text-purple-700">
+    {hash}
+  </span>
+);
+
+const TabButton = ({
+  active,
+  children,
+  onClick,
+}: {
+  active: boolean;
+  children: React.ReactNode;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`cursor-pointer overflow-clip rounded-full px-4 py-0.5 typo-button-md transition-colors ${
+      active
+        ? "bg-blue-50 text-blue-700"
+        : "text-(--color-text-secondary) hover:bg-(--color-action-hover)"
+    }`}
+  >
+    {children}
+  </button>
+);
+
+const CommitTableCard = ({
+  recommendedCommits,
+  linkedCommits,
+  footerStats,
+  className = "",
+}: CommitTableCardProps) => {
+  const [tab, setTab] = useState<CommitTab>("recommended");
+  const rows = tab === "recommended" ? recommendedCommits : linkedCommits;
+
+  return (
+    <GlassCard className={`gap-5 px-5 py-7 ${className}`}>
+      <div className="flex items-center justify-between">
+        <h2 className="typo-subtitle4 text-(--color-text-primary)">
+          커밋 추천 결과
+        </h2>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            aria-label="새로고침"
+            className="flex size-5 cursor-pointer items-center justify-center rounded bg-(--color-bg-surface) text-(--color-text-secondary) hover:bg-(--color-action-hover)"
+          >
+            <Icon icon={IconArrowsReload} size={16} />
+          </button>
+          <button
+            type="button"
+            aria-label="추가"
+            className="flex size-5 cursor-pointer items-center justify-center rounded bg-(--color-bg-surface) text-(--color-text-secondary) hover:bg-(--color-action-hover)"
+          >
+            <Icon icon={IconAddPlus} size={16} />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-start gap-1">
+        <TabButton
+          active={tab === "recommended"}
+          onClick={() => setTab("recommended")}
+        >
+          추천 커밋
+        </TabButton>
+        <TabButton active={tab === "linked"} onClick={() => setTab("linked")}>
+          연결된 커밋
+        </TabButton>
+      </div>
+
+      <div className="w-full min-w-0 overflow-x-auto rounded-lg">
+        <table className="w-full min-w-130 table-fixed border-collapse">
+          <colgroup>
+            <col className="w-[22%] min-w-30" />
+            <col className="w-[14%] min-w-20" />
+            <col className="w-auto" />
+            <col className="w-[14%] min-w-18" />
+            <col className="w-[12%] min-w-16" />
+          </colgroup>
+          <thead>
+            <tr className="border-b border-(--color-border-default)">
+              <th className="px-2 py-3 text-left typo-caption1 text-(--color-text-secondary) uppercase">
+                Repository
+              </th>
+              <th className="px-2 py-3 text-left typo-caption1 text-(--color-text-secondary) uppercase">
+                Commit
+              </th>
+              <th className="px-2 py-3 text-left typo-caption1 text-(--color-text-secondary) uppercase">
+                Message
+              </th>
+              <th className="px-2 py-3 text-center typo-caption1 text-(--color-text-secondary) uppercase">
+                추천 사유
+              </th>
+              <th className="px-2 py-3 text-right typo-caption1 text-(--color-text-secondary) uppercase">
+                연결
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-2 py-6 text-center typo-body6 text-(--color-text-tertiary)"
+                >
+                  표시할 커밋이 없습니다
+                </td>
+              </tr>
+            ) : (
+              rows.map((c, idx) => {
+                const isLast = idx === rows.length - 1;
+                return (
+                  <tr
+                    key={`${c.repository_name}-${c.commit_hash}-${c.message}-${c.reason_summary}`}
+                    className={
+                      isLast ? "border-b border-(--color-border-default)" : ""
+                    }
+                  >
+                    <td className="h-11 px-2 py-2.5">
+                      <p className="truncate typo-body5 text-(--color-text-primary)">
+                        {c.repository_name}
+                      </p>
+                    </td>
+                    <td className="h-11 px-2 py-2.5">
+                      <CommitHashBadge hash={c.commit_hash} />
+                    </td>
+                    <td className="h-11 px-2 py-2.5">
+                      <p className="truncate typo-subtitle5 text-(--color-text-primary)">
+                        {c.message}
+                      </p>
+                    </td>
+                    <td className="h-11 px-2 py-2.5 text-center">
+                      <button
+                        type="button"
+                        title={c.reason_summary}
+                        className="cursor-pointer typo-button-sm text-(--color-text-brand) hover:underline"
+                      >
+                        사유 보기
+                      </button>
+                    </td>
+                    <td className="h-11 px-2 py-2.5 text-right">
+                      <button
+                        type="button"
+                        className="cursor-pointer rounded bg-(--color-bg-brand-subtle) px-3 py-0.5 typo-button-sm text-(--color-text-brand) hover:opacity-80"
+                      >
+                        {c.is_linked ? "해제" : "연결"}
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex w-full items-start gap-5 typo-caption1 text-(--color-text-tertiary)">
+        <div className="flex items-center gap-1">
+          <span>근거 발언</span>
+          <span className="font-bold typo-button-sm">
+            {footerStats.evidence_utterance_count}개
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <span>참여자 합의도</span>
+          <span className="font-bold typo-button-sm">
+            {footerStats.participant_consensus_label}
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <span>결정 ↔ 구현 일치율</span>
+          <span className="font-bold typo-button-sm">
+            {footerStats.decision_implementation_match_rate}%
+          </span>
+        </div>
+      </div>
+    </GlassCard>
+  );
+};
+
+export default CommitTableCard;

--- a/src/pages/decisions/components/ConfidenceBadge.tsx
+++ b/src/pages/decisions/components/ConfidenceBadge.tsx
@@ -1,0 +1,13 @@
+interface ConfidenceBadgeProps {
+  score: number;
+}
+
+const ConfidenceBadge = ({ score }: ConfidenceBadgeProps) => {
+  return (
+    <span className="inline-flex items-center justify-center rounded-full bg-blue-50 px-3 py-0.5 typo-caption2 font-bold text-blue-700">
+      신뢰도 {score}점
+    </span>
+  );
+};
+
+export default ConfidenceBadge;

--- a/src/pages/decisions/components/ContextCard.tsx
+++ b/src/pages/decisions/components/ContextCard.tsx
@@ -1,0 +1,56 @@
+import IconCircleUser from "@/assets/icons/user/ic_circle_user.svg?react";
+import { Icon } from "@/components/common/Icon";
+import type { DecisionContextMessage } from "@/types/decision";
+import GlassCard from "./GlassCard";
+
+interface ContextCardProps {
+  messages: DecisionContextMessage[];
+  className?: string;
+}
+
+const ContextCard = ({ messages, className = "" }: ContextCardProps) => {
+  return (
+    <GlassCard className={`gap-5 px-5 py-7 ${className}`}>
+      <h2 className="typo-subtitle4 text-(--color-text-primary)">
+        결정 원문 맥락
+      </h2>
+
+      <div className="flex flex-1 flex-col gap-4 overflow-y-auto">
+        {messages.map((m) => (
+          <div
+            key={`${m.member_id}-${m.time}-${m.dialogue_content}`}
+            className="flex w-full items-start gap-2"
+          >
+            <Icon
+              icon={IconCircleUser}
+              size={28}
+              className="shrink-0 text-(--color-dark-100)"
+            />
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <div className="flex items-center gap-1">
+                <p className="typo-subtitle5 text-(--color-text-primary)">
+                  {m.member_name}
+                </p>
+                <p className="typo-caption1 text-(--color-text-secondary)">
+                  {m.time}
+                </p>
+              </div>
+              <div
+                className="bg-(--color-bg-surface) px-3 py-2"
+                style={{
+                  borderRadius: "2px 10px 10px 10px",
+                }}
+              >
+                <p className="typo-body5 text-(--color-text-primary)">
+                  {m.dialogue_content}
+                </p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </GlassCard>
+  );
+};
+
+export default ContextCard;

--- a/src/pages/decisions/components/DecisionHeader.tsx
+++ b/src/pages/decisions/components/DecisionHeader.tsx
@@ -1,0 +1,51 @@
+import IconCircleUser from "@/assets/icons/user/ic_circle_user.svg?react";
+import { Icon } from "@/components/common/Icon";
+import type { DecisionConfidence, DecisionMeetingMeta } from "@/types/decision";
+import ConfidenceBadge from "./ConfidenceBadge";
+
+interface DecisionHeaderProps {
+  name: string;
+  confidence: DecisionConfidence;
+  meta: DecisionMeetingMeta;
+}
+
+const Dot = () => (
+  <span className="typo-body6 text-(--color-text-secondary)">·</span>
+);
+
+const DecisionHeader = ({ name, confidence, meta }: DecisionHeaderProps) => {
+  const visibleAvatars = meta.participants.slice(0, 5);
+
+  return (
+    <header className="flex w-full flex-col gap-3">
+      <div className="flex items-center gap-3">
+        <h1 className="typo-h4 text-(--color-text-primary)">{name}</h1>
+        <ConfidenceBadge score={confidence.score} />
+      </div>
+
+      <div className="flex w-full items-center gap-2 typo-body6 text-(--color-text-secondary)">
+        <span>{meta.meeting_name}</span>
+        <Dot />
+        <span>{meta.meeting_date}</span>
+        <Dot />
+        <span>{meta.duration_label}</span>
+        <Dot />
+        <div className="flex items-center gap-1">
+          <div className="flex items-center pr-[3.5px]">
+            {visibleAvatars.map((p) => (
+              <Icon
+                key={p.member_id}
+                icon={IconCircleUser}
+                size={14}
+                className="-mr-[3.5px] shrink-0 rounded-full bg-white text-(--color-dark-100) ring-1 ring-white"
+              />
+            ))}
+          </div>
+          <span>{meta.participant_count}명 참여</span>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default DecisionHeader;

--- a/src/pages/decisions/components/GlassCard.tsx
+++ b/src/pages/decisions/components/GlassCard.tsx
@@ -1,0 +1,18 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+interface GlassCardProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+const GlassCard = ({ className = "", children, ...rest }: GlassCardProps) => {
+  return (
+    <div
+      className={`flex flex-col rounded-2xl border border-white bg-white/50 backdrop-blur-md ${className}`}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default GlassCard;

--- a/src/pages/decisions/components/ReasonsCard.tsx
+++ b/src/pages/decisions/components/ReasonsCard.tsx
@@ -1,0 +1,46 @@
+import IconNoteSearch from "@/assets/icons/file/ic_note_search.svg?react";
+import IconCircleCheck from "@/assets/icons/warning/ic_circle_check.svg?react";
+import { Icon } from "@/components/common/Icon";
+import type { DecisionReasonItem } from "@/types/decision";
+import GlassCard from "./GlassCard";
+
+interface ReasonsCardProps {
+  reasons: DecisionReasonItem[];
+  count: number;
+}
+
+const ReasonsCard = ({ reasons, count }: ReasonsCardProps) => {
+  return (
+    <GlassCard className="h-51 gap-3 overflow-hidden px-4 py-5">
+      <div className="flex items-center gap-1">
+        <Icon
+          icon={IconNoteSearch}
+          size={16}
+          className="text-(--color-text-primary)"
+        />
+        <p className="typo-body6 text-(--color-text-primary)">결정근거</p>
+        <p className="typo-caption2 text-(--color-text-secondary)">({count})</p>
+      </div>
+
+      <ul className="flex flex-1 flex-col gap-1 overflow-y-auto">
+        {reasons.map((reason) => (
+          <li
+            key={reason.reason_id}
+            className="flex items-center gap-2 rounded-lg px-2 py-1.5"
+          >
+            <Icon
+              icon={IconCircleCheck}
+              size={14}
+              className="shrink-0 text-(--color-text-brand)"
+            />
+            <p className="typo-body5 flex-1 text-(--color-text-primary)">
+              {reason.title}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </GlassCard>
+  );
+};
+
+export default ReasonsCard;

--- a/src/pages/decisions/components/TimelineCard.tsx
+++ b/src/pages/decisions/components/TimelineCard.tsx
@@ -1,0 +1,52 @@
+import IconClock from "@/assets/icons/media/ic_clock.svg?react";
+import { Icon } from "@/components/common/Icon";
+import type { DecisionTimelineItem } from "@/types/decision";
+import GlassCard from "./GlassCard";
+
+interface TimelineCardProps {
+  items: DecisionTimelineItem[];
+}
+
+const TimelineCard = ({ items }: TimelineCardProps) => {
+  return (
+    <GlassCard className="h-51 gap-3 overflow-hidden px-4 py-5">
+      <div className="flex items-center gap-1">
+        <Icon
+          icon={IconClock}
+          size={16}
+          className="text-(--color-text-primary)"
+        />
+        <p className="typo-body6 text-(--color-text-primary)">타임라인</p>
+      </div>
+
+      <div className="relative flex flex-1 flex-col gap-2 overflow-y-auto">
+        {/* 세로 연결선 */}
+        {items.length > 1 && (
+          <div
+            aria-hidden="true"
+            className="absolute top-4 bottom-4 left-4.75 w-px bg-(--color-border-default)"
+          />
+        )}
+        {items.map((item) => (
+          <div
+            key={`${item.time}-${item.step}-${item.content}`}
+            className="relative flex items-center gap-2 rounded-lg px-3 py-1.5"
+          >
+            <span
+              aria-hidden="true"
+              className="z-10 inline-block size-2 shrink-0 rounded-full bg-(--color-text-brand) ring-2 ring-white"
+            />
+            <p className="typo-caption2 shrink-0 text-(--color-text-secondary)">
+              {item.time}
+            </p>
+            <p className="typo-body5 flex-1 truncate text-(--color-text-primary)">
+              {item.content}
+            </p>
+          </div>
+        ))}
+      </div>
+    </GlassCard>
+  );
+};
+
+export default TimelineCard;

--- a/src/pages/decisions/mocks.ts
+++ b/src/pages/decisions/mocks.ts
@@ -1,0 +1,157 @@
+import type { DecisionDetailViewModel } from "@/types/decision";
+
+const avatar = (seed: string) => `https://i.pravatar.cc/56?u=${seed}`;
+
+export const MOCK_DECISION_DETAIL_VIEW_MODEL: DecisionDetailViewModel = {
+  detail: {
+    application_id: 1,
+    name: "Redis 키 정책 변경",
+    decision_timelines: [
+      { time: "12:24", step: "이슈제기", content: "장애 이슈 제기" },
+      { time: "12:26", step: "논의", content: "Redis vs Mongo 논의" },
+      { time: "12:28", step: "결정", content: "최종 결정" },
+    ],
+    decision_contexts: [
+      {
+        time: "12:24",
+        member_id: 1,
+        member_name: "김준용",
+        profile_image: avatar("kim"),
+        dialogue_content:
+          "Redis 키 만료 정책이 지금 TTL 고정인데, 세션 유형별로 다르게 가져가야 할 것 같아요. 지금 인증 세션이랑 캐시 세션이 같은 TTL인 게 문제인 거죠.",
+      },
+      {
+        time: "12:26",
+        member_id: 2,
+        member_name: "유진",
+        profile_image: avatar("yujin"),
+        dialogue_content:
+          "Mongo로 옮기자는 의견도 있었는데, 운영 복잡도 올라가니까 Redis 유지하면서 키 네이밍 규칙만 바꾸는 게 낫지 않을까요?",
+      },
+      {
+        time: "12:27",
+        member_id: 3,
+        member_name: "유상완",
+        profile_image: avatar("yoo"),
+        dialogue_content:
+          "저도 Redis 유지에 동의합니다. 메모리 비용 이슈는 키 정책 분리로 충분히 대응 가능할 것 같아요.",
+      },
+      {
+        time: "12:28",
+        member_id: 4,
+        member_name: "조윤지",
+        profile_image: avatar("cho"),
+        dialogue_content:
+          "좋습니다. 그럼 Redis 유지하고 키 정책만 세션 유형별로 분리하는 걸로 가겠습니다.",
+      },
+    ],
+    decision_reason_count: 2,
+    decision_reasons: [
+      { reason_id: "1", title: "운영 복잡도 우려로 보류" },
+      { reason_id: "2", title: "Redis 메모리 비용" },
+      { reason_id: "3", title: "Redis 메모리 비용" },
+    ],
+  },
+  application: {
+    application_id: 1,
+    repository_name: "whyLog-Backend",
+    commit_id: "1",
+    commit_hash: "b8fd9ad",
+    message: "feat: API 구현",
+    reason: "이 커밋은 관련된 이슈를 해결하는 커밋입니다.",
+  },
+  meta: {
+    meeting_name: "서버 개발 팀 4차 회의",
+    meeting_date: "2025.01.20",
+    duration_label: "회의 시간 47분",
+    participant_count: 5,
+    participants: [
+      { member_id: 1, name: "김준용", profile_image: avatar("kim") },
+      { member_id: 2, name: "유진", profile_image: avatar("yujin") },
+      { member_id: 3, name: "유상완", profile_image: avatar("yoo") },
+      { member_id: 4, name: "조윤지", profile_image: avatar("cho") },
+      { member_id: 5, name: "이도현", profile_image: avatar("lee") },
+    ],
+  },
+  confidence: { score: 90 },
+  applied_commits: [
+    {
+      application_id: 1,
+      repository_name: "Nect-Backend",
+      commit_id: "1",
+      commit_hash: "a13f9c2",
+      message: "feat: 세션 저장소 인터페이스 분리",
+      reason: "",
+    },
+    {
+      application_id: 2,
+      repository_name: "Nect-Backend",
+      commit_id: "2",
+      commit_hash: "a13f9c2",
+      message: "feat: 세션 저장소 인터페이스 분리",
+      reason: "",
+    },
+    {
+      application_id: 3,
+      repository_name: "Nect-Backend",
+      commit_id: "3",
+      commit_hash: "a13f9c2",
+      message: "refactor: 마이페이지 조회 성능 개선",
+      reason: "",
+    },
+  ],
+  recommended_commits: [
+    {
+      repository_name: "Nect-Backend",
+      commit_hash: "a13f9c2",
+      message: "feat: 마이페이지 API 구현",
+      reason_summary: "Redis 키 정책 분리 작업이 포함된 커밋",
+      is_linked: false,
+    },
+    {
+      repository_name: "Nect-Backend",
+      commit_hash: "a13f9c2",
+      message: "feat: 마이페이지 API 구현",
+      reason_summary: "세션 인터페이스 추출",
+      is_linked: false,
+    },
+    {
+      repository_name: "SpeakOn/Fe",
+      commit_hash: "a13f9c2",
+      message: "feat: 유저 프로필 컴포넌트 구현",
+      reason_summary: "관련 세션 처리 로직 변경",
+      is_linked: false,
+    },
+    {
+      repository_name: "Nect-Backend",
+      commit_hash: "a13f9c2",
+      message: "refactor: 코드 리팩토링",
+      reason_summary: "키 네이밍 규칙 정리",
+      is_linked: false,
+    },
+  ],
+  linked_commits: [
+    {
+      repository_name: "Nect-Backend",
+      commit_hash: "b8fd9ad",
+      message: "feat: API 구현",
+      reason_summary: "이 커밋은 관련된 이슈를 해결하는 커밋입니다.",
+      is_linked: true,
+    },
+  ],
+  footer_stats: {
+    evidence_utterance_count: 42,
+    participant_consensus_label: "높음",
+    decision_implementation_match_rate: 92,
+  },
+};
+
+/**
+ * TODO: API 연동 시 `useDecisionDetail(decisionId)` 와
+ * `useDecisionApplication(applicationId)` 두 개의 React Query 훅으로 교체.
+ * 현재는 id 무관하게 단일 mock 을 반환합니다.
+ */
+export const getMockDecisionDetail = (
+  _decisionId: number,
+  _applicationId: number,
+): DecisionDetailViewModel => MOCK_DECISION_DETAIL_VIEW_MODEL;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 export { default as DecisionsPage } from "./decisions";
+export { default as DecisionsRoutePage } from "./decisions/DecisionsRoutePage";
 export { default as GitPage } from "./git";
 export { default as HomePage } from "./home";
 export { default as LoginPage } from "./login";

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from "../constants/routes";
 import TeamLayout from "../layout/TeamLayout";
 import {
   DecisionsPage,
+  DecisionsRoutePage,
   GitPage,
   HomePage,
   LoginPage,
@@ -46,7 +47,7 @@ const allRoutes: RouteObject[] = [
       },
       {
         path: "decisions/:decisionId/:applicationId",
-        element: <DecisionsPage />,
+        element: <DecisionsRoutePage />,
       },
       {
         path: "meeting",

--- a/src/types/decision.ts
+++ b/src/types/decision.ts
@@ -1,0 +1,87 @@
+// GET /api/decisions/{decisionId}
+export interface DecisionTimelineItem {
+  time: string;
+  step: string;
+  content: string;
+}
+
+export interface DecisionContextMessage {
+  time: string;
+  member_id: number;
+  member_name: string;
+  profile_image: string;
+  dialogue_content: string;
+}
+
+export interface DecisionReasonItem {
+  reason_id: string;
+  title: string;
+}
+
+export interface DecisionDetail {
+  application_id: number;
+  name: string;
+  decision_timelines: DecisionTimelineItem[];
+  decision_contexts: DecisionContextMessage[];
+  decision_reason_count: number;
+  decision_reasons: DecisionReasonItem[];
+}
+
+// GET /api/decisions/{decisionId}/applications/{applicationId}
+export interface DecisionApplicationDetail {
+  application_id: number;
+  repository_name: string;
+  commit_id: string;
+  commit_hash: string;
+  message: string;
+  reason: string;
+}
+
+// =============================================================================
+// TODO: BE 스키마에 아직 없는 필드 — 추후 위 인터페이스로 흡수.
+// 디자인에 표현돼 있어 mock 단계에서만 사용하는 view-model 확장입니다.
+// =============================================================================
+
+export interface DecisionMeetingMeta {
+  meeting_name: string;
+  meeting_date: string; // "YYYY.MM.DD"
+  duration_label: string; // "회의 시간 47분"
+  participant_count: number;
+  participants: {
+    member_id: number;
+    name: string;
+    profile_image: string;
+  }[];
+}
+
+export interface DecisionConfidence {
+  score: number; // 0–100
+}
+
+export interface RecommendedCommit {
+  repository_name: string;
+  commit_hash: string;
+  message: string;
+  reason_summary: string;
+  is_linked: boolean;
+}
+
+export interface DecisionFooterStats {
+  evidence_utterance_count: number;
+  participant_consensus_label: string;
+  decision_implementation_match_rate: number; // 0–100
+}
+
+export type CommitTab = "recommended" | "linked";
+
+// 페이지가 소비하는 통합 view-model
+export interface DecisionDetailViewModel {
+  detail: DecisionDetail;
+  application: DecisionApplicationDetail;
+  meta: DecisionMeetingMeta;
+  confidence: DecisionConfidence;
+  applied_commits: DecisionApplicationDetail[];
+  recommended_commits: RecommendedCommit[];
+  linked_commits: RecommendedCommit[];
+  footer_stats: DecisionFooterStats;
+}


### PR DESCRIPTION
<!-- PR 제목 예시-> [Feat]: 소셜 로그인 기능 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
결정사항 페이지 mock 데이터로 ui 구현

## 📄 작업 내용
- AppLayout의 main 그라데이션 배경 추가
- 결정사항 페이지 ui 구현

## 📌 관련 이슈
- close #47 

## 📷 UI 스크린샷 (해당 시)
<!-- 전/후 비교 이미지 등 첨부 -->
<img width="1710" height="868" alt="Screenshot 2026-05-06 at 5 03 20 PM" src="https://github.com/user-attachments/assets/78437196-5866-4100-a674-9799a037dedc" />

## 💬 기타 사항
<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->
우선 mock 데이터 추가하여 ui만 구현했고, 추후 api 완료 되면 연동 하면서 다듬어보겠습니다!