### PR TITLE
[Fix]: 회의 종료 시 모달 추가

### DIFF
--- a/src/pages/meeting/InProgressPage.tsx
+++ b/src/pages/meeting/InProgressPage.tsx
@@ -71,6 +71,7 @@ const InProgressPage = () => {
     setMicrophoneEnabled,
     setAudioOutputEnabled,
     manualRetry,
+    isMeetingEnded,
   } = useMeetingRoom({
     meetingId,
     displayName: myName,
@@ -176,7 +177,20 @@ const InProgressPage = () => {
         />
       </div>
 
-      {isEndConfirmOpen && (
+      {isMeetingEnded && (
+        <Modal
+          title="회의가 종료되었어요"
+          onClose={() => navigate("/")}
+          primaryLabel="홈으로"
+          onPrimaryClick={() => navigate("/")}
+        >
+          <p className="typo-body-md text-(--color-text-secondary)">
+            다른 참가자가 회의를 종료했어요. 분석이 곧 시작됩니다.
+          </p>
+        </Modal>
+      )}
+
+      {isEndConfirmOpen && !isMeetingEnded && (
         <Modal
           title="회의를 종료하시겠어요?"
           onClose={() => setIsEndConfirmOpen(false)}

--- a/src/pages/meeting/InProgressPage.tsx
+++ b/src/pages/meeting/InProgressPage.tsx
@@ -78,7 +78,7 @@ const InProgressPage = () => {
   });
 
   const MAX_CONNECTION_RETRIES = 3;
-  const isConnecting = !isWsConnected || !isRoomConnected;
+  const isConnecting = !isMeetingEnded && (!isWsConnected || !isRoomConnected);
 
   const { handleInterim, handleFinal, mergeTranscripts, mergeInterim } =
     useLocalSpeechFallback({

--- a/src/pages/meeting/hooks/useLiveKitRoom.ts
+++ b/src/pages/meeting/hooks/useLiveKitRoom.ts
@@ -71,6 +71,27 @@ export const useLiveKitRoom = ({ meetingId }: UseLiveKitRoomOptions) => {
     });
   }, []);
 
+  const disconnect = useCallback(async () => {
+    const room = roomRef.current;
+    isMicEnabledRef.current = false;
+    setIsMicEnabled(false);
+    if (!room) {
+      setIsConnected(false);
+      return;
+    }
+    try {
+      await room.localParticipant.setMicrophoneEnabled(false);
+    } catch {
+      /* noop */
+    }
+    try {
+      await room.disconnect();
+    } catch {
+      /* noop */
+    }
+    setIsConnected(false);
+  }, []);
+
   const manualRetry = useCallback(() => {
     setErrorMessage(null);
     setRetryAttempt(0);
@@ -211,5 +232,6 @@ export const useLiveKitRoom = ({ meetingId }: UseLiveKitRoomOptions) => {
     setMicrophoneEnabled,
     setAudioOutputEnabled,
     manualRetry,
+    disconnect,
   };
 };

--- a/src/pages/meeting/hooks/useMeetingRoom.ts
+++ b/src/pages/meeting/hooks/useMeetingRoom.ts
@@ -39,10 +39,10 @@ export const useMeetingRoom = ({
 
   // 타인이 회의를 종료한 시그널이 오면 LiveKit Room/마이크 즉시 해제
   useEffect(() => {
-    if (signaling.isMeetingEnded) {
-      void livekit.disconnect();
-    }
-  }, [signaling.isMeetingEnded, livekit.disconnect]);
+    if (!signaling.isMeetingEnded) return;
+    void livekit.isConnected;
+    void livekit.disconnect();
+  }, [signaling.isMeetingEnded, livekit.isConnected, livekit.disconnect]);
 
   return {
     participants,

--- a/src/pages/meeting/hooks/useMeetingRoom.ts
+++ b/src/pages/meeting/hooks/useMeetingRoom.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import type { RoomParticipant } from "../types";
 import { useLiveKitRoom } from "./useLiveKitRoom";
 import { useMeetingSignaling } from "./useMeetingSignaling";
@@ -37,6 +37,13 @@ export const useMeetingRoom = ({
 
   const retryAttempt = Math.max(signaling.retryAttempt, livekit.retryAttempt);
 
+  // 타인이 회의를 종료한 시그널이 오면 LiveKit Room/마이크 즉시 해제
+  useEffect(() => {
+    if (signaling.isMeetingEnded) {
+      void livekit.disconnect();
+    }
+  }, [signaling.isMeetingEnded, livekit.disconnect]);
+
   return {
     participants,
     isWsConnected: signaling.isConnected,
@@ -53,5 +60,6 @@ export const useMeetingRoom = ({
     setMicrophoneEnabled: livekit.setMicrophoneEnabled,
     setAudioOutputEnabled: livekit.setAudioOutputEnabled,
     manualRetry,
+    isMeetingEnded: signaling.isMeetingEnded,
   };
 };

--- a/src/pages/meeting/hooks/useMeetingSignaling.ts
+++ b/src/pages/meeting/hooks/useMeetingSignaling.ts
@@ -54,6 +54,7 @@ export const useMeetingSignaling = ({
   const [isConnected, setIsConnected] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [retryAttempt, setRetryAttempt] = useState(0);
+  const [isMeetingEnded, setIsMeetingEnded] = useState(false);
   const [transcripts, setTranscripts] = useState<TranscriptEntry[]>([]);
   const [interimByMember, setInterimByMember] = useState<
     Record<string, InterimEntry>
@@ -73,6 +74,7 @@ export const useMeetingSignaling = ({
     setErrorMessage(null);
     setRetryAttempt(0);
     setIsConnected(false);
+    setIsMeetingEnded(false);
     setRetrySignal((n) => n + 1);
   }, []);
 
@@ -198,7 +200,7 @@ export const useMeetingSignaling = ({
               break;
             }
             case "meeting_ended": {
-              setErrorMessage("회의가 종료되었습니다.");
+              setIsMeetingEnded(true);
               break;
             }
             default:
@@ -267,6 +269,7 @@ export const useMeetingSignaling = ({
       setIsConnected(false);
       setTranscripts([]);
       setInterimByMember({});
+      setIsMeetingEnded(false);
     };
   }, [meetingId, displayName]);
 
@@ -279,5 +282,6 @@ export const useMeetingSignaling = ({
     interimByMember,
     sendMessage,
     manualRetry,
+    isMeetingEnded,
   };
 };


### PR DESCRIPTION
<!-- PR 제목 예시-> [Feat]: 소셜 로그인 기능 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
실시간 회의 중, 사용자가 회의 종료 시에 다른 사용자들에게도 회의 종료 모달 렌더링

## 📄 작업 내용
- 회의 종료 시 모달 추가


## 📌 관련 이슈
- close #75 


## 💬 기타 사항
<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->
배포 후 배포 환경에서 다시 테스트해 볼 계획입니다...ㅎㅎ