### PR TITLE
[Feat]: 결정사항 커밋 연결 해제 api 연동

### DIFF
--- a/src/apis/applications.ts
+++ b/src/apis/applications.ts
@@ -5,6 +5,8 @@ import type {
   ApplicationRecommendedCommit,
   LinkCommitRequest,
   LinkCommitResult,
+  UnlinkCommitRequest,
+  UnlinkCommitResult,
 } from "@/types/application";
 import type { ApiResponse } from "@/types/auth";
 import { http } from "@/utils/http";
@@ -43,6 +45,20 @@ export const linkCommit = async (
     LinkCommitRequest,
     { data: ApiResponse<LinkCommitResult> }
   >(ENDPOINT.APPLICATIONS.LINK_COMMIT(applicationId), payload);
+  if (!data.isSuccess) {
+    throw new Error(data.message);
+  }
+  return data.result;
+};
+
+export const unlinkCommit = async (
+  applicationId: number,
+  payload: UnlinkCommitRequest,
+): Promise<UnlinkCommitResult> => {
+  const { data } = await http.delete<
+    unknown,
+    { data: ApiResponse<UnlinkCommitResult> }
+  >(ENDPOINT.APPLICATIONS.LINK_COMMIT(applicationId), { data: payload });
   if (!data.isSuccess) {
     throw new Error(data.message);
   }

--- a/src/pages/decisions/components/CommitTableCard.tsx
+++ b/src/pages/decisions/components/CommitTableCard.tsx
@@ -12,6 +12,7 @@ import type { CommitTab, DecisionFooterStats } from "@/types/decision";
 import { APPLICATION_CONNECTED_COMMITS_QUERY_KEY } from "../hooks/useConnectedCommits";
 import { useLinkCommit } from "../hooks/useLinkCommit";
 import { APPLICATION_RECOMMENDED_COMMITS_QUERY_KEY } from "../hooks/useRecommendedCommits";
+import { useUnlinkCommit } from "../hooks/useUnlinkCommit";
 import GlassCard from "./GlassCard";
 
 interface CommitTableCardProps {
@@ -185,6 +186,11 @@ const CommitTableCard = ({
     pendingCommitIds,
     errorMessage: linkErrorMessage,
   } = useLinkCommit(applicationId);
+  const {
+    unlinkCommit,
+    pendingCommitId: pendingUnlinkCommitId,
+    errorMessage: unlinkErrorMessage,
+  } = useUnlinkCommit(applicationId);
   const rowCount =
     tab === "recommended" ? recommendedCommits.length : linkedCommits.length;
 
@@ -329,9 +335,10 @@ const CommitTableCard = ({
             ) : (
               linkedCommits.map((c, idx) => {
                 const isLast = idx === linkedCommits.length - 1;
+                const isRowPending = pendingUnlinkCommitId === c.commit_id;
                 return (
                   <tr
-                    key={`linked-${c.repository_name}-${c.commit_hash}`}
+                    key={`linked-${c.commit_id}`}
                     className={
                       isLast ? "border-b border-(--color-border-default)" : ""
                     }
@@ -357,9 +364,11 @@ const CommitTableCard = ({
                     <td className="h-11 px-2 py-2.5 text-right">
                       <button
                         type="button"
-                        className="cursor-pointer rounded bg-(--color-bg-brand-subtle) px-3 py-0.5 typo-button-sm text-(--color-text-brand) hover:opacity-80"
+                        onClick={() => unlinkCommit(c.commit_id)}
+                        disabled={isRowPending}
+                        className="cursor-pointer rounded bg-(--color-bg-brand-subtle) px-3 py-0.5 typo-button-sm text-(--color-text-brand) hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
                       >
-                        해제
+                        {isRowPending ? "해제 중..." : "해제"}
                       </button>
                     </td>
                   </tr>
@@ -370,9 +379,9 @@ const CommitTableCard = ({
         </table>
       </div>
 
-      {linkErrorMessage ? (
+      {linkErrorMessage || unlinkErrorMessage ? (
         <p className="typo-caption1 text-(--color-text-error)">
-          {linkErrorMessage}
+          {linkErrorMessage ?? unlinkErrorMessage}
         </p>
       ) : null}
 

--- a/src/pages/decisions/hooks/useUnlinkCommit.ts
+++ b/src/pages/decisions/hooks/useUnlinkCommit.ts
@@ -1,0 +1,59 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+import { useState } from "react";
+import { unlinkCommit } from "@/apis/applications";
+import type { ApiResponse } from "@/types/auth";
+import { APPLICATION_CONNECTED_COMMITS_QUERY_KEY } from "./useConnectedCommits";
+import { APPLICATION_RECOMMENDED_COMMITS_QUERY_KEY } from "./useRecommendedCommits";
+
+interface UseUnlinkCommitOptions {
+  onSuccess?: () => void;
+}
+
+export const useUnlinkCommit = (
+  applicationId: number,
+  options?: UseUnlinkCommitOptions,
+) => {
+  const queryClient = useQueryClient();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: (commitId: number) =>
+      unlinkCommit(applicationId, { commit_id: commitId }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: [
+            ...APPLICATION_RECOMMENDED_COMMITS_QUERY_KEY,
+            applicationId,
+          ],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [...APPLICATION_CONNECTED_COMMITS_QUERY_KEY, applicationId],
+        }),
+      ]);
+      options?.onSuccess?.();
+    },
+    onError: (error: unknown) => {
+      if (isAxiosError<ApiResponse<unknown>>(error)) {
+        setErrorMessage(
+          error.response?.data?.message ??
+            "커밋 연결 해제에 실패했습니다. 다시 시도해주세요.",
+        );
+        return;
+      }
+      setErrorMessage("커밋 연결 해제에 실패했습니다. 다시 시도해주세요.");
+    },
+  });
+
+  return {
+    unlinkCommit: (commitId: number) => {
+      setErrorMessage(null);
+      mutation.mutate(commitId);
+    },
+    pendingCommitId: mutation.isPending ? mutation.variables : null,
+    isPending: mutation.isPending,
+    errorMessage,
+    resetError: () => setErrorMessage(null),
+  };
+};

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -39,6 +39,7 @@ export interface ApplicationRecommendedCommit {
 // GET /api/applications/{applicationId}/connected-commits
 export interface ApplicationConnectedCommit {
   repository_name: string;
+  commit_id: number;
   commit_hash: string;
   message: string;
   committed_date: string;
@@ -55,6 +56,16 @@ export interface LinkCommitRequest {
 }
 
 export interface LinkCommitResult {
+  application_id: number;
+  commit_ids: number[];
+}
+
+// DELETE /api/applications/{applicationId}/commits
+export interface UnlinkCommitRequest {
+  commit_id: number;
+}
+
+export interface UnlinkCommitResult {
   application_id: number;
   commit_ids: number[];
 }


### PR DESCRIPTION
<!-- PR 제목 예시-> [Feat]: 소셜 로그인 기능 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
결정사항 커밋 연결 해제 api 연동

## 📄 작업 내용
- 연결된 커밋 조회 api 응답에 commit_id 추가
- 결정사항 커밋 연결 해제 api 연동

## 📌 관련 이슈
- close #77 