### PR TITLE
[Fix]: 완료된 회의 페이지 사용자 프로필 이미지 표시 오류 수정

### DIFF
--- a/src/pages/meeting/components/CompletedMeetingHeader.tsx
+++ b/src/pages/meeting/components/CompletedMeetingHeader.tsx
@@ -64,11 +64,19 @@ const CompletedMeetingHeader = ({
               key={idx}
               className="flex items-center gap-1 rounded-full bg-(--color-bg-subtle) px-2 py-1"
             >
-              <Icon
-                icon={IconCircleUser}
-                size={20}
-                className="text-(--color-dark-100)"
-              />
+              {m.profile_image ? (
+                <img
+                  src={m.profile_image}
+                  alt={m.name}
+                  className="size-5 shrink-0 rounded-full object-cover"
+                />
+              ) : (
+                <Icon
+                  icon={IconCircleUser}
+                  size={20}
+                  className="text-(--color-dark-100)"
+                />
+              )}
               <span className="typo-caption text-(--color-text-secondary)">
                 {m.name}
               </span>

--- a/src/pages/meeting/components/CompletedTranscript.tsx
+++ b/src/pages/meeting/components/CompletedTranscript.tsx
@@ -11,12 +11,20 @@ const CompletedTranscript = ({ items }: CompletedTranscriptProps) => {
     <div className="flex flex-1 flex-col gap-5 overflow-y-auto pr-2">
       {items.map((item) => (
         <div key={item.id} className="flex items-start gap-3">
-          <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-(--color-bg-subtle)">
-            <Icon
-              icon={IconCircleUser}
-              size={24}
-              className="text-(--color-dark-100)"
-            />
+          <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-(--color-bg-subtle)">
+            {item.profile_image ? (
+              <img
+                src={item.profile_image}
+                alt={item.name}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <Icon
+                icon={IconCircleUser}
+                size={24}
+                className="text-(--color-dark-100)"
+              />
+            )}
           </span>
           <div className="flex flex-1 flex-col gap-1">
             <div className="flex items-baseline gap-2">


### PR DESCRIPTION
<!-- PR 제목 예시-> [Feat]: 소셜 로그인 기능 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
완료된 회의 페이지 대화 기록 및 대화 내역 사용자 프로필 이미지 표시 오류 수정

## 📄 작업 내용
- 완료된 회의 페이지 사용자 프로필 이미지 표시 오류 수정

## 📌 관련 이슈
- close #90 

## 📷 UI 스크린샷 (해당 시)
<!-- 전/후 비교 이미지 등 첨부 -->
<img width="683" height="444" alt="image" src="https://github.com/user-attachments/assets/73af1453-91c1-4f17-a369-ae09a790839e" />