### PR TITLE
[Feat] 깃 페이지 로딩 UI 구현

### DIFF
--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -11,7 +11,7 @@ const LoadingSpinner = ({
 }: LoadingSpinnerProps) => {
   return (
     <div
-      className={`flex min-h-[calc(100vh-120px)] w-full items-center justify-center ${className}`}
+      className={`flex h-full min-h-screen w-full items-center justify-center ${className}`}
       role="status"
       aria-live="polite"
     >

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -1,0 +1,29 @@
+import LoadingSpinnerUrl from "@/assets/illustrations/empty_state_illustration.svg";
+
+interface LoadingSpinnerProps {
+  className?: string;
+  size?: number;
+}
+
+const LoadingSpinner = ({
+  className = "",
+  size = 160,
+}: LoadingSpinnerProps) => {
+  return (
+    <div
+      className={`flex min-h-[calc(100vh-120px)] w-full items-center justify-center ${className}`}
+      role="status"
+      aria-live="polite"
+    >
+      <img
+        src={LoadingSpinnerUrl}
+        alt=""
+        aria-hidden="true"
+        width={size}
+        height={size}
+      />
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/src/pages/git/CommitDetailPage.tsx
+++ b/src/pages/git/CommitDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { useCurrentTeam } from "@/hooks/useCurrentTeam";
 import GlassCard from "@/pages/decisions/components/GlassCard";
 import { parseRouteId } from "@/utils/parseRouteId";
@@ -31,10 +32,11 @@ const CommitDetailPage = () => {
     }
   }, [repositories, selectedRepository, navigate, teamId]);
 
-  const { data: commitDetailData } = useGetCommitDetail(
-    selectedRepository?.repository_id ?? null,
-    params.commitHash,
-  );
+  const { data: commitDetailData, isLoading: isCommitDetailLoading } =
+    useGetCommitDetail(
+      selectedRepository?.repository_id ?? null,
+      params.commitHash,
+    );
 
   const detail = useMemo(
     () =>
@@ -53,6 +55,10 @@ const CommitDetailPage = () => {
     }
     void navigate(`/team/${teamId}/git`);
   };
+
+  if (isCommitDetailLoading) {
+    return <LoadingSpinner />;
+  }
 
   return (
     <div className="flex w-full flex-col py-[60px]">


### PR DESCRIPTION
<!-- PR 제목 예시-> [Feat]: 소셜 로그인 기능 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
깃 커밋 상세 페이지에서 커밋 상세 API 호출 중 로딩 상태를 표시하도록 구현했습니다.
공통 로딩 스피너 컴포넌트도 함께 추가했습니다.

## 📄 작업 내용
- 공통 `LoadingSpinner` 컴포넌트 구현
- 커밋 상세 API 호출 중 `LoadingSpinner`가 표시되도록 적용

## 📌 관련 이슈
- close #98 

## 📷 UI 스크린샷 (해당 시)
<!-- 전/후 비교 이미지 등 첨부 -->
<img width="1470" height="803" alt="image" src="https://github.com/user-attachments/assets/4ee6d369-645f-4b12-a6c7-1e946ced8c5b" />


## 💬 기타 사항
<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->
