### PR TITLE
[Fix]: 회의시간 연동 수정 및 멤버 프로필 이미지 수정 추가

### DIFF
--- a/src/components/common/MemberAvatar.tsx
+++ b/src/components/common/MemberAvatar.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import IconCircleUser from "@/assets/icons/user/ic_circle_user.svg?react";
+import { Icon } from "@/components/common/Icon";
+
+interface MemberAvatarProps {
+  src?: string | null;
+  alt?: string;
+  size?: number;
+  className?: string;
+}
+
+/**
+ * 멤버 프로필 아바타.
+ * - src가 있고 로드에 성공하면 이미지를 표시
+ * - 없거나 로드 실패 시 기본 아이콘으로 폴백
+ */
+const MemberAvatar = ({
+  src,
+  alt = "프로필 이미지",
+  size = 32,
+  className = "",
+}: MemberAvatarProps) => {
+  const [hasError, setHasError] = useState(false);
+  const showImage = !!src && !hasError;
+
+  return (
+    <span
+      className={`flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-(--color-bg-subtle) ${className}`}
+      style={{ width: size, height: size }}
+    >
+      {showImage ? (
+        <img
+          src={src as string}
+          alt={alt}
+          className="size-full object-cover"
+          loading="lazy"
+          onError={() => setHasError(true)}
+        />
+      ) : (
+        <Icon
+          icon={IconCircleUser}
+          size={Math.round(size * 0.75)}
+          className="text-(--color-dark-100)"
+        />
+      )}
+    </span>
+  );
+};
+
+export default MemberAvatar;

--- a/src/pages/meeting/CompletedPage.tsx
+++ b/src/pages/meeting/CompletedPage.tsx
@@ -47,6 +47,15 @@ const formatDurationText = (seconds: number | null | undefined) => {
   return `${m}분`;
 };
 
+const formatDurationFromMinutes = (minutes: number | null | undefined) => {
+  if (minutes == null || minutes <= 0) return "0분";
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (h > 0 && m > 0) return `${h}시간 ${m}분`;
+  if (h > 0) return `${h}시간`;
+  return `${m}분`;
+};
+
 const buildPanels = (
   analysis: MeetingAnalysis | undefined,
 ): CompletedMeetingPanels => {
@@ -112,7 +121,7 @@ const CompletedPage = () => {
 
   const name = detail?.name ?? "";
   const startText = formatStartText(detail?.start_date_time);
-  const durationText = formatDurationText(detail?.duration);
+  const durationText = formatDurationFromMinutes(detail?.duration);
   const memberCount = detail?.member_count ?? 0;
   const members =
     detail?.members?.map((m) => ({

--- a/src/pages/meeting/CompletedPage.tsx
+++ b/src/pages/meeting/CompletedPage.tsx
@@ -136,7 +136,7 @@ const CompletedPage = () => {
   return (
     <div className="flex h-full flex-col gap-6 py-10">
       <div className="flex flex-1 gap-6 overflow-hidden">
-        <section className="flex flex-1 flex-col gap-5 overflow-hidden rounded-2xl border border-(--color-border-default) bg-(--color-bg-surface) px-6 py-6">
+        <section className="flex flex-1 flex-col gap-5 overflow-hidden rounded-2xl border border-white bg-white/50 px-6 py-6 backdrop-blur-md">
           <CompletedMeetingHeader
             name={name}
             startText={startText}

--- a/src/pages/meeting/components/info-panels/InfoPanelCard.tsx
+++ b/src/pages/meeting/components/info-panels/InfoPanelCard.tsx
@@ -22,7 +22,7 @@ const EditPenIcon = () => (
 
 const InfoPanelCard = ({ title, items }: InfoPanelCardProps) => {
   return (
-    <section className="flex flex-col gap-3 rounded-2xl border border-(--color-border-default) bg-(--color-bg-surface) px-5 py-4">
+    <section className="flex flex-col gap-3 rounded-2xl border border-white bg-white/50 px-5 py-4 backdrop-blur-md">
       <div className="flex items-center justify-between">
         <h3 className="typo-subtitle4 text-(--color-text-primary)">{title}</h3>
         <button

--- a/src/pages/settings/hooks/useUploadProfileImage.ts
+++ b/src/pages/settings/hooks/useUploadProfileImage.ts
@@ -1,0 +1,52 @@
+import { useMutation } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+import { useState } from "react";
+import { uploadMemberProfileImage } from "@/apis/auth";
+import type { ApiResponse } from "@/types/auth";
+
+export const PROFILE_IMAGE_STORAGE_KEY = "profile_image_url";
+
+/**
+ * 프로필 이미지 업로드 처리.
+ * - 성공: 반환된 profile_image_url을 localStorage에 저장하고 uploadedUrl로 노출
+ * - 실패: 에러 메시지를 hook에서 노출
+ *
+ * 멤버 프로필 조회 GET API가 없으므로, 마지막 업로드 결과를 localStorage에 저장해
+ * 새로고침 후에도 유지한다.
+ */
+export const useUploadProfileImage = () => {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: (image: File) => uploadMemberProfileImage(image),
+    onSuccess: (result) => {
+      const url = result.profile_image_url;
+      setUploadedUrl(url);
+      try {
+        localStorage.setItem(PROFILE_IMAGE_STORAGE_KEY, url);
+      } catch {
+        // localStorage 접근 불가 시 무시 (세션 내 표시는 유지)
+      }
+    },
+    onError: (err: unknown) => {
+      if (isAxiosError<ApiResponse<unknown>>(err)) {
+        setErrorMessage(
+          err.response?.data?.message ?? "프로필 이미지 업로드에 실패했습니다.",
+        );
+        return;
+      }
+      setErrorMessage("프로필 이미지 업로드에 실패했습니다.");
+    },
+  });
+
+  return {
+    uploadProfileImage: (image: File) => {
+      setErrorMessage(null);
+      mutation.mutate(image);
+    },
+    isPending: mutation.isPending,
+    errorMessage,
+    uploadedUrl,
+  };
+};

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import MemberAvatar from "@/components/common/MemberAvatar";
 import Modal from "@/components/common/Modal";
 import { useCurrentTeam } from "@/hooks/useCurrentTeam";
+import GlassCard from "@/pages/decisions/components/GlassCard";
 import { useDeleteTeam } from "./hooks/useDeleteTeam";
 import {
   PROFILE_IMAGE_STORAGE_KEY,
@@ -66,7 +67,7 @@ const SettingsPage = () => {
         </p>
       </header>
 
-      <section className="flex flex-col gap-3 rounded-2xl border border-(--color-border-default) bg-(--color-bg-surface) px-6 py-5">
+      <GlassCard className="gap-3 px-6 py-5">
         <h2 className="typo-subtitle3 text-(--color-text-primary)">
           내 프로필
         </h2>
@@ -99,9 +100,9 @@ const SettingsPage = () => {
             )}
           </div>
         </div>
-      </section>
+      </GlassCard>
 
-      <section className="flex flex-col gap-3 rounded-2xl border border-(--color-border-default) bg-(--color-bg-surface) px-6 py-5">
+      <GlassCard className="gap-3 px-6 py-5">
         <h2 className="typo-subtitle3 text-(--color-text-primary)">팀 정보</h2>
         <dl className="flex flex-col gap-2">
           <div className="flex items-center gap-3">
@@ -113,7 +114,7 @@ const SettingsPage = () => {
             </dd>
           </div>
         </dl>
-      </section>
+      </GlassCard>
 
       <div>
         <button

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,7 +1,12 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import MemberAvatar from "@/components/common/MemberAvatar";
 import Modal from "@/components/common/Modal";
 import { useCurrentTeam } from "@/hooks/useCurrentTeam";
 import { useDeleteTeam } from "./hooks/useDeleteTeam";
+import {
+  PROFILE_IMAGE_STORAGE_KEY,
+  useUploadProfileImage,
+} from "./hooks/useUploadProfileImage";
 
 const SettingsPage = () => {
   const { teamId, currentTeam, isLoading } = useCurrentTeam();
@@ -12,6 +17,46 @@ const SettingsPage = () => {
   } = useDeleteTeam();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
+  const {
+    uploadProfileImage,
+    isPending: isUploading,
+    errorMessage: uploadError,
+    uploadedUrl,
+  } = useUploadProfileImage();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [storedUrl, setStoredUrl] = useState<string | null>(null);
+  const [localPreview, setLocalPreview] = useState<string | null>(null);
+
+  // 최초 진입 시 마지막 업로드 이미지(localStorage) 복원
+  useEffect(() => {
+    try {
+      setStoredUrl(localStorage.getItem(PROFILE_IMAGE_STORAGE_KEY));
+    } catch {
+      setStoredUrl(null);
+    }
+  }, []);
+
+  // 로컬 미리보기 objectURL 정리
+  useEffect(() => {
+    return () => {
+      if (localPreview) URL.revokeObjectURL(localPreview);
+    };
+  }, [localPreview]);
+
+  const handleProfileFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    // 같은 파일 재선택 허용
+    e.target.value = "";
+    if (!file) return;
+    setLocalPreview((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return URL.createObjectURL(file);
+    });
+    uploadProfileImage(file);
+  };
+
+  const profileImageSrc = localPreview ?? uploadedUrl ?? storedUrl;
+
   return (
     <div className="flex h-full flex-col gap-6 py-10">
       <header className="flex flex-col gap-1">
@@ -20,6 +65,41 @@ const SettingsPage = () => {
           팀 정보를 관리합니다.
         </p>
       </header>
+
+      <section className="flex flex-col gap-3 rounded-2xl border border-(--color-border-default) bg-(--color-bg-surface) px-6 py-5">
+        <h2 className="typo-subtitle3 text-(--color-text-primary)">
+          내 프로필
+        </h2>
+        <div className="flex items-center gap-4">
+          <button
+            type="button"
+            className="cursor-pointer rounded-full ring-(--color-border-default) transition hover:ring-2 disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={isUploading}
+            aria-label="프로필 사진 변경"
+          >
+            <MemberAvatar src={profileImageSrc} size={64} />
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleProfileFileChange}
+            aria-label="프로필 사진 파일 선택"
+          />
+          <div className="flex flex-col gap-1">
+            <span className="typo-body6 text-(--color-text-tertiary)">
+              {isUploading
+                ? "업로드 중..."
+                : "사진을 클릭하여 프로필 이미지를 변경하세요."}
+            </span>
+            {uploadError && (
+              <span className="typo-caption text-red-500">{uploadError}</span>
+            )}
+          </div>
+        </div>
+      </section>
 
       <section className="flex flex-col gap-3 rounded-2xl border border-(--color-border-default) bg-(--color-bg-surface) px-6 py-5">
         <h2 className="typo-subtitle3 text-(--color-text-primary)">팀 정보</h2>


### PR DESCRIPTION
<!-- PR 제목 예시-> [Feat]: 소셜 로그인 기능 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
회의시간 연동 수정 및 멤버 프로필 이미지 수정 추가
회의 완료, 설정 페이지 ui 수정

## 📄 작업 내용
- 회의시간 연동 수정
- 멤버 프로필 이미지 수정 추가
- 회의 완료, 설정 페이지 ui 수정


## 📌 관련 이슈
- close #89 

## 📷 UI 스크린샷 (해당 시)
<!-- 전/후 비교 이미지 등 첨부 -->
<img width="2870" height="1972" alt="image" src="https://github.com/user-attachments/assets/203b8b11-4622-413d-ae31-a6e79da0ae6f" />


<img width="1424" height="970" alt="image" src="https://github.com/user-attachments/assets/4b852fbb-dd64-45ce-bf5c-7836a8137f18" />


