### PR TITLE
[Fix]: 결정사항 페이지 회의 정보 api 수정

### DIFF
--- a/src/pages/decisions/DecisionsRoutePage.tsx
+++ b/src/pages/decisions/DecisionsRoutePage.tsx
@@ -1,5 +1,11 @@
 import { useParams } from "react-router-dom";
-import type { DecisionDetailViewModel } from "@/types/decision";
+import { useMeetingDetail } from "@/pages/meeting/hooks/useMeetingDetail";
+import type {
+  DecisionDetailViewModel,
+  DecisionMeetingMeta,
+} from "@/types/decision";
+import type { MeetingDetail } from "@/types/meeting";
+import { formatCommittedDate } from "@/utils/date";
 import { parseRouteId } from "@/utils/parseRouteId";
 import DecisionDetailPage from "./DecisionDetailPage";
 import { useApplicationDetail } from "./hooks/useApplicationDetail";
@@ -8,6 +14,18 @@ import { useDecisionReliability } from "./hooks/useDecisionReliability";
 import { useRecommendedCommits } from "./hooks/useRecommendedCommits";
 import DecisionsPage from "./index";
 import { MOCK_DECISION_DETAIL_VIEW_MODEL } from "./mocks";
+
+const toMeetingMeta = (m: MeetingDetail): DecisionMeetingMeta => ({
+  meeting_name: m.name,
+  meeting_date: formatCommittedDate(m.start_date_time),
+  duration_label: m.duration != null ? `회의 시간 ${m.duration}분` : "회의 시간 -",
+  participant_count: m.member_count,
+  participants: m.members.map((p) => ({
+    member_id: p.member_id,
+    name: p.name,
+    profile_image: p.profile_image ?? "",
+  })),
+});
 
 const DecisionsRoutePage = () => {
   const { decisionId: decisionIdParam, applicationId: applicationIdParam } =
@@ -19,6 +37,7 @@ const DecisionsRoutePage = () => {
   const recommendedQuery = useRecommendedCommits(applicationId);
   const connectedQuery = useConnectedCommits(applicationId);
   const reliabilityQuery = useDecisionReliability(decisionId);
+  const meetingQuery = useMeetingDetail(detailQuery.data?.meeting_id ?? null);
 
   if (decisionId == null || applicationId == null) {
     return <DecisionsPage />;
@@ -27,9 +46,13 @@ const DecisionsRoutePage = () => {
   const isLoading =
     detailQuery.isLoading ||
     recommendedQuery.isLoading ||
-    connectedQuery.isLoading;
+    connectedQuery.isLoading ||
+    meetingQuery.isLoading;
   const error =
-    detailQuery.error ?? recommendedQuery.error ?? connectedQuery.error;
+    detailQuery.error ??
+    recommendedQuery.error ??
+    connectedQuery.error ??
+    meetingQuery.error;
 
   if (isLoading) {
     return (
@@ -51,7 +74,9 @@ const DecisionsRoutePage = () => {
   const vm: DecisionDetailViewModel = {
     detail: detailQuery.data,
     application: MOCK_DECISION_DETAIL_VIEW_MODEL.application,
-    meta: MOCK_DECISION_DETAIL_VIEW_MODEL.meta,
+    meta: meetingQuery.data
+      ? toMeetingMeta(meetingQuery.data)
+      : MOCK_DECISION_DETAIL_VIEW_MODEL.meta,
     confidence:
       reliabilityQuery.data ?? MOCK_DECISION_DETAIL_VIEW_MODEL.confidence,
     applied_commits: MOCK_DECISION_DETAIL_VIEW_MODEL.applied_commits,

--- a/src/pages/decisions/DecisionsRoutePage.tsx
+++ b/src/pages/decisions/DecisionsRoutePage.tsx
@@ -18,7 +18,8 @@ import { MOCK_DECISION_DETAIL_VIEW_MODEL } from "./mocks";
 const toMeetingMeta = (m: MeetingDetail): DecisionMeetingMeta => ({
   meeting_name: m.name,
   meeting_date: formatCommittedDate(m.start_date_time),
-  duration_label: m.duration != null ? `회의 시간 ${m.duration}분` : "회의 시간 -",
+  duration_label:
+    m.duration != null ? `회의 시간 ${m.duration}분` : "회의 시간 -",
   participant_count: m.member_count,
   participants: m.members.map((p) => ({
     member_id: p.member_id,
@@ -46,13 +47,9 @@ const DecisionsRoutePage = () => {
   const isLoading =
     detailQuery.isLoading ||
     recommendedQuery.isLoading ||
-    connectedQuery.isLoading ||
-    meetingQuery.isLoading;
+    connectedQuery.isLoading;
   const error =
-    detailQuery.error ??
-    recommendedQuery.error ??
-    connectedQuery.error ??
-    meetingQuery.error;
+    detailQuery.error ?? recommendedQuery.error ?? connectedQuery.error;
 
   if (isLoading) {
     return (

--- a/src/pages/decisions/components/DecisionHeader.tsx
+++ b/src/pages/decisions/components/DecisionHeader.tsx
@@ -32,14 +32,23 @@ const DecisionHeader = ({ name, confidence, meta }: DecisionHeaderProps) => {
         <Dot />
         <div className="flex items-center gap-1">
           <div className="flex items-center pr-[3.5px]">
-            {visibleAvatars.map((p) => (
-              <Icon
-                key={p.member_id}
-                icon={IconCircleUser}
-                size={14}
-                className="-mr-[3.5px] shrink-0 rounded-full bg-white text-(--color-dark-100) ring-1 ring-white"
-              />
-            ))}
+            {visibleAvatars.map((p) =>
+              p.profile_image ? (
+                <img
+                  key={p.member_id}
+                  src={p.profile_image}
+                  alt={p.name}
+                  className="-mr-[3.5px] size-3.5 shrink-0 rounded-full object-cover ring-1 ring-white"
+                />
+              ) : (
+                <Icon
+                  key={p.member_id}
+                  icon={IconCircleUser}
+                  size={14}
+                  className="-mr-[3.5px] shrink-0 rounded-full bg-white text-(--color-dark-100) ring-1 ring-white"
+                />
+              ),
+            )}
           </div>
           <span>{meta.participant_count}명 참여</span>
         </div>

--- a/src/pages/meeting/components/MeetingHeader.tsx
+++ b/src/pages/meeting/components/MeetingHeader.tsx
@@ -42,18 +42,27 @@ const MeetingHeader = ({
           WS {isWsConnected ? "✓" : "…"} · RTC {isRoomConnected ? "✓" : "…"}
         </span>
         <div className="flex -space-x-2">
-          {participants.slice(0, 3).map((p) => (
-            <span
-              key={p.id}
-              className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-(--color-bg-surface) bg-light-500"
-            >
-              <Icon
-                icon={IconCircleUser}
-                size={20}
-                className="text-(--color-dark-100)"
+          {participants.slice(0, 3).map((p) =>
+            p.profileImage ? (
+              <img
+                key={p.id}
+                src={p.profileImage}
+                alt={p.name}
+                className="h-7 w-7 rounded-full border-2 border-(--color-bg-surface) object-cover"
               />
-            </span>
-          ))}
+            ) : (
+              <span
+                key={p.id}
+                className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-(--color-bg-surface) bg-light-500"
+              >
+                <Icon
+                  icon={IconCircleUser}
+                  size={20}
+                  className="text-(--color-dark-100)"
+                />
+              </span>
+            ),
+          )}
         </div>
       </div>
     </div>

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -20,6 +20,7 @@ export interface ApplicationReasonItem {
 
 export interface ApplicationDetail {
   application_id: number;
+  meeting_id: number;
   name: string;
   decision_timelines: ApplicationTimelineItem[];
   decision_contexts: ApplicationContextMessage[];


### PR DESCRIPTION
<!-- PR 제목 예시-> [Feat]: 소셜 로그인 기능 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
결정사항 조희 api에 meeting_id 필드가 추가되었고, meeting_id로 회의 정보를 받아옵니다.

## 📄 작업 내용
- 결정사항 페이지 회의 정보 api 수정
- 실시간 회의 헤더 참여자 프로필 이미지 표시

## 📌 관련 이슈
- close #111 
